### PR TITLE
uses \n instead of environment newline to avoid issues on windows

### DIFF
--- a/src/Typesense/Client.cs
+++ b/src/Typesense/Client.cs
@@ -158,7 +158,7 @@ namespace Typesense
             foreach (var document in documents)
             {
                 var json = JsonSerializer.Serialize(document, jsonOptions);
-                jsonString.Append(json + Environment.NewLine);
+                jsonString.Append(json + '\n');
             }
 
             var response = await _httpClient.PostAsync(path, new StringContent(jsonString.ToString(), Encoding.UTF8, "text/plain"));
@@ -168,7 +168,7 @@ namespace Typesense
 
             var responseString = Encoding.UTF8.GetString(await response.Content.ReadAsByteArrayAsync());
 
-            return responseString.Split(Environment.NewLine).Select((x) => JsonSerializer.Deserialize<ImportResponse>(x)).ToList();
+            return responseString.Split('\n').Select((x) => JsonSerializer.Deserialize<ImportResponse>(x)).ToList();
         }
 
         public async Task<List<T>> ExportDocuments<T>(string collection)
@@ -179,7 +179,7 @@ namespace Typesense
             var response = await Get($"/collections/{collection}/documents/export");
 
             var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-            return response.Split(Environment.NewLine).Select((x) => JsonSerializer.Deserialize<T>(x, jsonOptions)).ToList();
+            return response.Split('\n').Select((x) => JsonSerializer.Deserialize<T>(x, jsonOptions)).ToList();
         }
 
         private void ConfigureHttpClient()


### PR DESCRIPTION
`Environment.NewLine` equals to \r\n in windows and Typesense does not seem to support the official jsonl spec, that supports `\r\n` https://jsonlines.org/, so it will be fixed here. 

The code in Typesense can be found here.
https://github.com/typesense/typesense/blob/353344d671529707fceaa66756c925bb9599bfc6/src/core_api.cpp#L408