### PR TITLE
now uses generic type T for create and upsert document

### DIFF
--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -23,7 +23,7 @@ namespace Typesense
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="TypesenseApiException"></exception>
-        Task<T> CreateDocument<T>(string collection, object document);
+        Task<T> CreateDocument<T>(string collection, T document);
 
         /// <summary>
         /// Inserts the document if it does not exist or update if the document exist.
@@ -34,7 +34,7 @@ namespace Typesense
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
         /// <exception cref="TypesenseApiException"></exception>
-        Task<T> UpsertDocument<T>(string collection, object document);
+        Task<T> UpsertDocument<T>(string collection, T document);
 
         /// <summary>
         /// Search for a document in the specified collection using the supplied search parameters.

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -31,7 +31,7 @@ namespace Typesense
             return JsonSerializer.Deserialize<CollectionResponse>(response);
         }
 
-        public async Task<T> CreateDocument<T>(string collection, object document)
+        public async Task<T> CreateDocument<T>(string collection, T document)
         {
             if (collection is null || document is null)
                 throw new ArgumentNullException($"{nameof(collection)} or {nameof(document)} cannot be null.");
@@ -43,7 +43,7 @@ namespace Typesense
             return JsonSerializer.Deserialize<T>(response, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
         }
 
-        public async Task<T> UpsertDocument<T>(string collection, object document)
+        public async Task<T> UpsertDocument<T>(string collection, T document)
         {
             if (collection is null || document is null)
                 throw new ArgumentNullException($"{nameof(collection)} or {nameof(document)} cannot be null.");


### PR DESCRIPTION
Now uses generic type `T` for `UpsertDocument` and `CreateDocument`, I decided to do this to better show that it is the same type that is used as the parameter that will returned.