### PR TITLE
moves all config to config namespace

### DIFF
--- a/src/Typesense/Setup/Config.cs
+++ b/src/Typesense/Setup/Config.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Typesense
+namespace Typesense.Setup
 {
     public class Config
     {

--- a/src/Typesense/Setup/Node.cs
+++ b/src/Typesense/Setup/Node.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Typesense
+namespace Typesense.Setup
 {
     /// <summary>
     /// The node contains the configuration for a remote Typesense service.

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using Typesense.Setup;
 
 namespace Typesense
 {


### PR DESCRIPTION
Moves all the configuration options to the `Typesense.Config` namespace.