### PR TITLE
Generate scoped search key

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ var keys = await typesenseClient.ListKeys();
 var deletedKey = await typesenseClient.DeleteKey(0);
 ```
 
+### Generate Scoped Search key
+
+``` c#
+var scopedSearchKey = typesenseClient.GenerateScopedSearchKey("MainOrParentAPIKey", "{\"filter_by\":\"accessible_to_user_ids:2\"}");
+```
+
 ## Curation
 
 While Typesense makes it really easy and intuitive to deliver great search results, sometimes you might want to promote certain documents over others. Or, you might want to exclude certain documents from a query's result set.

--- a/examples/Example/Program.cs
+++ b/examples/Example/Program.cs
@@ -146,6 +146,11 @@ class Program
         var listKeys = await typesenseClient.ListKeys();
         Console.WriteLine($"List keys: {JsonSerializer.Serialize(listKeys)}");
 
+        var scopedSearchKey = typesenseClient.GenerateScopedSearchKey(
+            createKeyResultOne.Value, "{\"filter_by\":\"accessible_to_user_ids:2\"}");
+        
+        Console.WriteLine($"Scoped Search Key: {scopedSearchKey}");
+
         // Curation
         var searchOverride = new SearchOverride(new List<Include> { new Include("2", 1) }, new Rule("Sul", "exact"));
         var upsertSearchOverrideResponse = await typesenseClient.UpsertSearchOverride(

--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -178,6 +178,22 @@ public interface ITypesenseClient
     /// <returns>List of all keys.</returns>
     /// <exception cref="TypesenseApiException"></exception>
     Task<ListKeysResponse> ListKeys();
+    
+    /// <summary>
+    /// Generate scoped search API keys without having to make any calls to the Typesense server.
+    /// By using an API key with a search scope (only), create an HMAC digest of the parameters.
+    /// With this scoped-generated key, you can use it as an API key.
+    ///
+    /// Remember to never expose your main/parent search key client-side.
+    /// </summary>
+    /// <param name="securityKey">Main/Parent API Key as the security</param>
+    /// <param name="parameters">
+    /// Embed search parameters as json. Example: "{"filter_by": "company_id:124", "expires_at": 1906054106}".
+    /// You can also set a custom expires_at for a scoped API key. The expiration for a scoped API key should be less
+    /// than the expiration of the parent API key with which it is generated. expires_at is optional.
+    /// </param>
+    /// <returns>Scope API key</returns>
+    string GenerateScopedSearchKey(string securityKey, string parameters);
 
     /// <summary>
     /// Upsert search override.


### PR DESCRIPTION
Typesense allows you to create API Keys with fine-grained access control. You can restrict access on a per-collection, per-action, per-record or even per-field level or a mixture of these.

https://typesense.org/docs/0.22.1/api/api-keys.html#generate-scoped-search-key