### PR TITLE
Add param to support non-indexed fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ var typesenseClient = provider.GetService<ITypesenseClient>();
 
 ## Create collection
 
-When you create the collection, you can specify each field with `name`, `type` and if it should be a `facet` or be an `optional` field.
+When you create the collection, you can specify each field with `name`, `type` and if it should be a `facet`, an `optional` or an `indexed` field.
 
 ``` c#
 var schema = new Schema
@@ -45,6 +45,7 @@ var schema = new Schema
         new Field("id", FieldType.Int32, false),
         new Field("houseNumber", FieldType.Int32, false),
         new Field("accessAddress", FieldType.String, false, true),
+        new Field("metadataNotes", FieldType.String, false, true, false),
     },
     DefaultSortingField = "id"
 };

--- a/examples/Example/Address.cs
+++ b/examples/Example/Address.cs
@@ -5,4 +5,5 @@ public class Address
     public string Id { get; set; }
     public int HouseNumber { get; set; }
     public string AccessAddress { get; set; }
+    public string MetadataNotes { get; set; }
 }

--- a/examples/Example/Program.cs
+++ b/examples/Example/Program.cs
@@ -29,6 +29,7 @@ class Program
                     new Field("id", FieldType.String, false),
                     new Field("houseNumber", FieldType.Int32, false),
                     new Field("accessAddress", FieldType.String, false, true),
+                    new Field("metadataNotes", FieldType.String, false, true, false),
                 },
             DefaultSortingField = "houseNumber"
         };
@@ -66,6 +67,14 @@ class Program
             HouseNumber = 3,
         };
 
+        // Example to show non indexed field
+        var addressFive = new Address
+        {
+            HouseNumber = 12,
+            AccessAddress = "Singel 12",
+            MetadataNotes = "This is not indexed and will not use memory"
+        };
+
         var houseOneResponse = await typesenseClient.CreateDocument<Address>("Addresses", addressOne);
         Console.WriteLine($"Created document: {JsonSerializer.Serialize(houseOneResponse)}");
         var houseTwoResponse = await typesenseClient.CreateDocument<Address>("Addresses", addressTwo);
@@ -74,6 +83,8 @@ class Program
         Console.WriteLine($"Created document: {JsonSerializer.Serialize(houseThreeResponse)}");
         var houseFourResponse = await typesenseClient.CreateDocument<Address>("Addresses", addressFour);
         Console.WriteLine($"Created document: {JsonSerializer.Serialize(houseFourResponse)}");
+        var houseFiveResponse = await typesenseClient.CreateDocument<Address>("Addresses", addressFive);
+        Console.WriteLine($"Created document: {JsonSerializer.Serialize(houseFiveResponse)}");
 
         var exportResult = await typesenseClient.ExportDocuments<Address>("Addresses");
         Console.WriteLine($"Export result: {JsonSerializer.Serialize(exportResult)}");

--- a/src/Typesense/Field.cs
+++ b/src/Typesense/Field.cs
@@ -15,23 +15,27 @@ public record Field
     public bool Facet { get; init; }
     [JsonPropertyName("optional")]
     public bool Optional { get; init; }
+    [JsonPropertyName("index")]
+    public bool Index { get; init; }
 
     [JsonConstructor]
-    public Field(string name, FieldType type, bool facet, bool optional = false)
+    public Field(string name, FieldType type, bool facet, bool optional = false, bool index = true)
     {
         Name = name;
         Type = type;
         Facet = facet;
         Optional = optional;
+        Index = index;
     }
 
     [Obsolete("A better choice going forward is using the constructor with 'FieldType' enum instead.")]
-    public Field(string name, string type, bool facet, bool optional = false)
+    public Field(string name, string type, bool facet, bool optional = false, bool index = true)
     {
         Name = name;
         Type = MapFieldType(type);
         Facet = facet;
         Optional = optional;
+        Index = index;
     }
 
     private static FieldType MapFieldType(string fieldType)


### PR DESCRIPTION
https://typesense.org/docs/0.22.2/api/collections.html#indexing-all-but-some-fields

> **Indexing all but some fields**
>
> If you have a case where you do want to index all fields in the document, except for a few fields, you can use the index: false setting to exclude fields.
