### PR TITLE
Fixes error when using array type as indexed fields for matched tokens

### DIFF
--- a/src/Typesense/Converter/MatchedTokenConverter.cs
+++ b/src/Typesense/Converter/MatchedTokenConverter.cs
@@ -12,22 +12,26 @@ public class MatchedTokenConverter : JsonConverter<IReadOnlyList<object>>
         var jsonDocument = JsonDocument.ParseValue(ref reader);
         var matchedTokens = new List<object>();
 
-        foreach (var element in jsonDocument.RootElement.EnumerateArray())
+        foreach(var element in jsonDocument.RootElement.EnumerateArray())
         {
-            var elementValue = element.GetString();
-            if (elementValue is null)
-                throw new ArgumentNullException(nameof(elementValue));
-
-            if (element.ValueKind == JsonValueKind.String)
+            if(element.ValueKind == JsonValueKind.String)
             {
+                var elementValue = element.GetString();
+                if(elementValue is null)
+                    throw new ArgumentNullException(nameof(elementValue));
+
                 matchedTokens.Add(elementValue);
             }
-            else if (element.ValueKind == JsonValueKind.Array)
+            else if(element.ValueKind == JsonValueKind.Array)
             {
                 var stringElements = new List<string>();
-                foreach (var stringElement in element.EnumerateArray())
+                foreach(var stringElement in element.EnumerateArray())
                 {
-                    stringElements.Add(elementValue);
+                    var stringElementValue = stringElement.GetString();
+                    if(stringElementValue is null)
+                        throw new ArgumentNullException(nameof(stringElementValue));
+
+                    stringElements.Add(stringElementValue);
                 }
 
                 matchedTokens.Add(stringElements);


### PR DESCRIPTION
When using an array type, the matched tokens return a nested array of matched tokens for each element in the indexed array. This is currently not supported in typesense-dotnet.

as `var elementValue = element.GetString();` inside the matched token converter will throw due to the inner type being an array. I've added a test for both types to make sure i didn't break anything by doing this, but things should be good. 