### PR TITLE
Fix/export documents params

### DIFF
--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -212,6 +212,7 @@ public class TypesenseClient : ITypesenseClient
         var response = await Get($"/collections/{collection}/documents/export?{searchParameters}").ConfigureAwait(false);
 
         return response.Split('\n')
+            .Where(x => !string.IsNullOrWhiteSpace(x))
             .Select((x) => JsonSerializer.Deserialize<T>(x, _jsonNameCaseInsentiveTrue)
                     ?? throw new ArgumentException("Null is not valid for documents"))
             .ToList();

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -202,7 +202,7 @@ public class TypesenseClient : ITypesenseClient
 
         var extraParameters = new List<string>();
         if (exportParameters.IncludeFields is not null)
-            extraParameters.Add($"include_fields={exportParameters.ExcludeFields}");
+            extraParameters.Add($"include_fields={exportParameters.IncludeFields}");
         if (exportParameters.FilterBy is not null)
             extraParameters.Add($"filter_by={exportParameters.FilterBy}");
         if (exportParameters.ExcludeFields is not null)

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -370,6 +370,93 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         response.OrderBy(x => x.Id).Should().BeEquivalentTo(expected);
     }
 
+    [Fact, TestPriority(8)]
+    public async Task Export_documents_filter_by_query()
+    {
+        var expected = new List<Company>
+        {
+            new Company
+            {
+                Id = "124",
+                CompanyName = "Stark Industries",
+                NumEmployees = 5215,
+                Country = "USA",
+            }
+        };
+
+        var response = await _client.ExportDocuments<Company>("companies", new ExportParameters { FilterBy = "id: [124]" });
+
+        response.OrderBy(x => x.Id).Should().BeEquivalentTo(expected);
+    }
+
+    [Fact, TestPriority(8)]
+    public async Task Export_documents_include_fields()
+    {
+        var expected = new List<Company>
+        {
+            new Company
+            {
+                Id = "124",
+                CompanyName = "Stark Industries"
+            },
+            new Company
+            {
+                Id = "125",
+                CompanyName = "Future Technology"
+            },
+            new Company
+            {
+                Id = "126",
+                CompanyName = "Random Corp."
+            },
+            new Company
+            {
+                Id = "999",
+                CompanyName = "Awesome A/S"
+            }
+        };
+
+        var response = await _client.ExportDocuments<Company>("companies", new ExportParameters { IncludeFields = "id,company_name" });
+
+        response.OrderBy(x => x.Id).Should().BeEquivalentTo(expected);
+    }
+
+    [Fact, TestPriority(8)]
+    public async Task Export_documents_exclude_fields()
+    {
+        var expected = new List<Company>
+        {
+            new Company
+            {
+                Id = "124",
+                CompanyName = "Stark Industries",
+                Country = "USA",
+            },
+            new Company
+            {
+                Id = "125",
+                CompanyName = "Future Technology",
+                Country = "UK",
+            },
+            new Company
+            {
+                Id = "126",
+                CompanyName = "Random Corp.",
+                Country = "AU",
+            },
+            new Company
+            {
+                Id = "999",
+                CompanyName = "Awesome A/S",
+                Country = "SWE",
+            }
+        };
+
+        var response = await _client.ExportDocuments<Company>("companies", new ExportParameters { ExcludeFields = "num_employees" });
+
+        response.OrderBy(x => x.Id).Should().BeEquivalentTo(expected);
+    }
+
     [Fact, TestPriority(9)]
     public async Task Retrieve_document()
     {


### PR DESCRIPTION
Found a small bug with the `include_fields` param. And when using filtering the response has a trailing newline, decided to filter out any empty lines (but tbh it's a [bug in typesense](https://github.com/typesense/typesense/issues/622)).