### PR TITLE
Fix/facet stats

### DIFF
--- a/src/Typesense/SearchResult.cs
+++ b/src/Typesense/SearchResult.cs
@@ -86,21 +86,27 @@ public record FacetCountHit
 public record FacetStats
 {
     [JsonPropertyName("avg")]
-    public int Average { get; init; }
+    public float Average { get; init; }
 
     [JsonPropertyName("max")]
-    public int Max { get; init; }
+    public float Max { get; init; }
 
     [JsonPropertyName("min")]
-    public int Min { get; init; }
+    public float Min { get; init; }
 
     [JsonPropertyName("sum")]
-    public int Sum { get; init; }
+    public float Sum { get; init; }
 
     [JsonPropertyName("total_values")]
     public int TotalValues { get; init; }
 
-    public FacetStats(int average, int max, int min, int sum, int totalValues)
+    [JsonConstructor]
+    public FacetStats(
+        float average,
+        float max,
+        float min,
+        float sum,
+        int totalValues)
     {
         Average = average;
         Max = max;

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -40,7 +40,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<Field>
             {
                 new Field("company_name", FieldType.String, false, false, true, false),
-                new Field("num_employees", FieldType.Int32, false, false, true, true),
+                new Field("num_employees", FieldType.Int32, true, false, true, true),
                 new Field("country", FieldType.String, true, false, true, false),
             },
             "num_employees");
@@ -50,7 +50,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<Field>
             {
                 new Field("company_name", FieldType.String, false),
-                new Field("num_employees", FieldType.Int32, false),
+                new Field("num_employees", FieldType.Int32, true),
                 new Field("country", FieldType.String, true),
             },
             "num_employees");
@@ -98,7 +98,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<Field>
             {
                 new Field("company_name", FieldType.String, false, false, true, false),
-                new Field("num_employees", FieldType.Int32, false, false, true, true),
+                new Field("num_employees", FieldType.Int32, true, false, true, true),
                 new Field("country", FieldType.String, true, false, true, false),
             },
             "num_employees");
@@ -119,7 +119,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new List<Field>
                 {
                     new Field("company_name", FieldType.String, false, false, true, false),
-                    new Field("num_employees", FieldType.Int32, false, false, true, true),
+                    new Field("num_employees", FieldType.Int32, true, false, true, true),
                     new Field("country", FieldType.String, true, false, true, false),
                 },
                 "num_employees")
@@ -138,7 +138,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<Field>
             {
                 new Field("company_name", FieldType.String, false, false, true, false),
-                new Field("num_employees", FieldType.Int32, false, false, true, true),
+                new Field("num_employees", FieldType.Int32, true, false, true, true),
                 new Field("country", FieldType.String, true, false, true, false),
             },
             "num_employees");
@@ -558,6 +558,31 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
     }
 
     [Fact, TestPriority(11)]
+    public async Task Search_facet_by_num_employees()
+    {
+        var expected = new FacetCount("num_employees", new List<FacetCountHit>
+            {
+                new FacetCountHit( "10", 1, "10"),
+                new FacetCountHit( "531", 1, "531"),
+                new FacetCountHit( "1232", 1, "1232"),
+                new FacetCountHit( "6000", 1, "6000"),
+            }, new FacetStats(1943.25F, 6000F, 10F, 7773F, 4));
+
+        var query = new SearchParameters("", "company_name")
+        {
+            FacetBy = "num_employees"
+        };
+
+        var response = await _client.Search<Company>("companies", query);
+
+        using (var scope = new AssertionScope())
+        {
+            response.FacetCounts.Should().HaveCount(1);
+            response.FacetCounts.First().Should().BeEquivalentTo(expected);
+        }
+    }
+
+    [Fact, TestPriority(11)]
     public async Task Search_facet_by_country_with_query()
     {
         var expected = new FacetCount("country", new List<FacetCountHit>
@@ -962,7 +987,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<Field>
             {
                 new Field("company_name", FieldType.String, false),
-                new Field("num_employees", FieldType.Int32, false),
+                new Field("num_employees", FieldType.Int32, true),
                 new Field("country", FieldType.String, true),
             },
             "num_employees");


### PR DESCRIPTION
I was looking at an old spec, stats field types are floats. Most recent spec:
https://github.com/typesense/typesense-api-spec/blob/master/openapi.yml#L2001
The stats are available for numerical facets, I've added a test for it.