### PR TITLE
now supports token separator and symbols to index

### DIFF
--- a/src/Typesense/CollectionResponse.cs
+++ b/src/Typesense/CollectionResponse.cs
@@ -7,23 +7,36 @@ public record CollectionResponse
 {
     [JsonPropertyName("name")]
     public string Name { get; init; }
+
     [JsonPropertyName("num_documents")]
     public int NumberOfDocuments { get; init; }
+
     [JsonPropertyName("fields")]
     public IReadOnlyCollection<Field> Fields { get; init; }
+
     [JsonPropertyName("default_sorting_field")]
     public string DefaultSortingField { get; init; }
+
+    [JsonPropertyName("token_separators")]
+    public IReadOnlyCollection<string> TokenSeparators { get; init; }
+
+    [JsonPropertyName("symbols_to_index")]
+    public IReadOnlyCollection<string> SymbolsToIndex { get; init; }
 
     [JsonConstructor]
     public CollectionResponse(
         string name,
         int numberOfDocuments,
         IReadOnlyCollection<Field> fields,
-        string defaultSortingField)
+        string defaultSortingField,
+        IReadOnlyCollection<string> tokenSeparators,
+        IReadOnlyCollection<string> symbolsToIndex)
     {
         Name = name;
         NumberOfDocuments = numberOfDocuments;
         Fields = fields;
         DefaultSortingField = defaultSortingField;
+        TokenSeparators = tokenSeparators;
+        SymbolsToIndex = symbolsToIndex;
     }
 }

--- a/src/Typesense/Schema.cs
+++ b/src/Typesense/Schema.cs
@@ -8,10 +8,18 @@ public record Schema
 {
     [JsonPropertyName("name")]
     public string Name { get; init; }
+
     [JsonPropertyName("fields")]
     public IEnumerable<Field> Fields { get; init; }
+
     [JsonPropertyName("default_sorting_field")]
     public string? DefaultSortingField { get; init; }
+
+    [JsonPropertyName("token_separators")]
+    public IEnumerable<string>? TokenSeparators { get; init; }
+
+    [JsonPropertyName("symbols_to_index")]
+    public IEnumerable<string>? SymbolsToIndex { get; init; }
 
     [Obsolete("Use multi-arity constructor instead.")]
     public Schema()

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -43,7 +43,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new Field("num_employees", FieldType.Int32, true, false, true, true),
                 new Field("country", FieldType.String, true, false, true, false),
             },
-            "num_employees");
+            "num_employees",
+            new List<string>(),
+            new List<string>());
 
         var schema = new Schema(
             "companies",
@@ -60,6 +62,44 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         response.Should().BeEquivalentTo(expected);
     }
 
+    [Fact, TestPriority(0)]
+    public async Task Create_schema_symbols_to_index_and_token_seperator()
+    {
+        var expected = new CollectionResponse(
+            "companies_with_symbols_and_token",
+            0,
+            new List<Field>
+            {
+                new Field("company_name", FieldType.String, false, false, true, false),
+                new Field("num_employees", FieldType.Int32, true, false, true, true),
+                new Field("country", FieldType.String, true, false, true, false),
+            },
+            "num_employees",
+            new List<string> { "-" },
+            new List<string> { "+" });
+
+        var schema = new Schema(
+            "companies_with_symbols_and_token",
+            new List<Field>
+            {
+                new Field("company_name", FieldType.String, false),
+                new Field("num_employees", FieldType.Int32, true),
+                new Field("country", FieldType.String, true),
+            },
+            "num_employees")
+        {
+            TokenSeparators = new List<string> { "-" },
+            SymbolsToIndex = new List<string> { "+" }
+        };
+
+        var response = await _client.CreateCollection(schema);
+
+        response.Should().BeEquivalentTo(expected);
+
+        // Cleanup
+        await _client.DeleteCollection(schema.Name);
+    }
+
     // We test wildcard field individually,
     // because it is a bit different than other types of fields.
     [Fact, TestPriority(0)]
@@ -72,7 +112,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             {
                 new Field(".*", FieldType.String, false, true, true, false),
             },
-            "");
+            "",
+            new List<string>(),
+            new List<string>());
 
         var schema = new Schema(
             "wildcard-collection",
@@ -101,7 +143,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new Field("num_employees", FieldType.Int32, true, false, true, true),
                 new Field("country", FieldType.String, true, false, true, false),
             },
-            "num_employees");
+            "num_employees",
+            new List<string>(),
+            new List<string>());
 
         var response = await _client.RetrieveCollection("companies");
 
@@ -122,7 +166,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     new Field("num_employees", FieldType.Int32, true, false, true, true),
                     new Field("country", FieldType.String, true, false, true, false),
                 },
-                "num_employees")
+                "num_employees",
+                new List<string>(),
+                new List<string>())
     };
 
         var response = await _client.RetrieveCollections();
@@ -141,7 +187,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new Field("num_employees", FieldType.Int32, true, false, true, true),
                 new Field("country", FieldType.String, true, false, true, false),
             },
-            "num_employees");
+            "num_employees",
+            new List<string>(),
+            new List<string>());
 
         var result = await _client.DeleteCollection("companies");
 


### PR DESCRIPTION
Fixes issue https://github.com/DAXGRID/typesense-dotnet/issues/99

Implements token separator and symbols to index referenced here.
https://github.com/typesense/typesense/issues/122