### PR TITLE
feat: grouped hits

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ var query = new SearchParameters("Smed", "accessAddress");
 var searchResult = await typesenseClient.Search<Address>("Addresses", query);
 ```
 
+## Search grouped
+
+```c#
+var query = new GroupedSearchParameters("Stark", "company_name", "country");
+var response = await _client.SearchGrouped<Company>("companies", query);
+```
+
 ## Multi search documents
 
 Multi search goes from one query to four, if you need more than that please open an issue and I'll implement more.

--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -77,7 +77,7 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
     /// <returns>The search result.</returns>
-    Task<GroupedSearchResult<T>> SearchGrouped<T>(string collection, SearchParameters searchParameters);
+    Task<SearchGroupedResult<T>> SearchGrouped<T>(string collection, GroupedSearchParameters groupedSearchParameters);
 
     /// <summary>
     /// Multiple Searches for documents in the specified collections using the supplied search parameters.

--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -66,6 +66,20 @@ public interface ITypesenseClient
     Task<SearchResult<T>> Search<T>(string collection, SearchParameters searchParameters);
 
     /// <summary>
+    /// Search for a document in the specified collection using the supplied search parameters, returning a grouped result.
+    /// </summary>
+    /// <param name="collection">The collection name.</param>
+    /// <param name="searchParameters">The search parameters.</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="TypesenseApiException"></exception>
+    /// <exception cref="TypesenseApiBadRequestException"></exception>
+    /// <exception cref="TypesenseApiNotFoundException"></exception>
+    /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
+    /// <returns>The search result.</returns>
+    Task<GroupedSearchResult<T>> SearchGrouped<T>(string collection, SearchParameters searchParameters);
+
+    /// <summary>
     /// Multiple Searches for documents in the specified collections using the supplied search parameters.
     /// </summary>
     /// <param name="s1">First search parameters.</param>

--- a/src/Typesense/SearchParameters.cs
+++ b/src/Typesense/SearchParameters.cs
@@ -117,14 +117,6 @@ public record SearchParameters
     public string? PerPage { get; set; }
 
     /// <summary>
-    /// You can aggregate search results into groups or buckets by specify
-    /// one or more `group_by` fields. Separate multiple fields with a comma.
-    /// To group on a particular field, it must be a faceted field.
-    /// </summary>
-    [JsonPropertyName("group_by")]
-    public string? GroupBy { get; set; }
-
-    /// <summary>
     /// Maximum number of hits to be returned for every group. If the `group_limit` is
     /// set as `K` then only the top K hits in each group are returned in the response.
     /// </summary>
@@ -280,5 +272,24 @@ public record SearchParameters
     {
         Text = text;
         QueryBy = queryBy;
+    }
+}
+
+public record GroupedSearchParameters : SearchParameters
+{
+    /// <summary>
+    /// You can aggregate search results into groups or buckets by specify
+    /// one or more `group_by` fields. Separate multiple fields with a comma.
+    /// To group on a particular field, it must be a faceted field.
+    /// </summary>
+    [JsonPropertyName("group_by")]
+    public string? GroupBy { get; set; }
+
+    public GroupedSearchParameters(
+        string text,
+        string queryBy,
+        string groupBy) : base(text, queryBy)
+    {
+        GroupBy = groupBy;
     }
 }

--- a/src/Typesense/SearchResult.cs
+++ b/src/Typesense/SearchResult.cs
@@ -49,10 +49,10 @@ public record FacetCount
 {
     [JsonPropertyName("counts")]
     public IReadOnlyList<FacetCountHit> Counts { get; init; }
-    
+
     [JsonPropertyName("field_name")]
     public string FieldName { get; init; }
-    
+
     [JsonPropertyName("stats")]
     public FacetStats Stats { get; init; }
 
@@ -68,13 +68,13 @@ public record FacetCountHit
 {
     [JsonPropertyName("count")]
     public int Count { get; init; }
-    
+
     [JsonPropertyName("highlighted")]
     public string Highlighted { get; init; }
-    
+
     [JsonPropertyName("value")]
     public string Value { get; init; }
-    
+
     public FacetCountHit(string value, int count, string highlighted)
     {
         Value = value;
@@ -120,9 +120,16 @@ public record GroupedHit<T>
 {
     [JsonPropertyName("group_key")]
     public IReadOnlyList<string> GroupKey { get; init; }
-    
+
     [JsonPropertyName("hits")]
     public IReadOnlyList<Hit<T>> Hits { get; init; }
+
+    [JsonConstructor]
+    public GroupedHit(IReadOnlyList<string> groupKey, IReadOnlyList<Hit<T>> hits)
+    {
+        GroupKey = groupKey;
+        Hits = hits;
+    }
 }
 
 public abstract record SearchResultBase
@@ -141,24 +148,68 @@ public abstract record SearchResultBase
     [JsonPropertyName("took_ms")]
     [Obsolete("Obsolete since version v0.18.0 use SearchTimeMs instead.")]
     public int? TookMs { get; init; }
+
+    [JsonConstructor]
+    protected SearchResultBase(
+        IReadOnlyCollection<FacetCount> facetCounts,
+        int found,
+        int outOf,
+        int page,
+        int searchTimeMs,
+        int? tookMs)
+    {
+        FacetCounts = facetCounts;
+        Found = found;
+        OutOf = outOf;
+        Page = page;
+        SearchTimeMs = searchTimeMs;
+        TookMs = tookMs;
+    }
 }
 
 public record SearchResult<T> : SearchResultBase
 {
     [JsonPropertyName("hits")]
     public IReadOnlyList<Hit<T>> Hits { get; init; }
+
+    [JsonConstructor]
+    public SearchResult(
+        IReadOnlyCollection<FacetCount> facetCounts,
+        int found,
+        int outOf,
+        int page, int searchTimeMs,
+        int? tookMs,
+        IReadOnlyList<Hit<T>> hits) : base(facetCounts, found, outOf, page, searchTimeMs, tookMs)
+    {
+        Hits = hits;
+    }
 }
 
-public record GroupedSearchResult<T> : SearchResultBase
+public record SearchGroupedResult<T> : SearchResultBase
 {
     [JsonPropertyName("grouped_hits")]
     public IReadOnlyList<GroupedHit<T>> GroupedHits { get; init; }
+
+    [JsonConstructor]
+    public SearchGroupedResult(
+        IReadOnlyCollection<FacetCount> facetCounts,
+        int found,
+        int outOf,
+        int page,
+        int searchTimeMs,
+        int? tookMs,
+        IReadOnlyList<GroupedHit<T>> groupedHits
+    ) : base(facetCounts, found, outOf, page, searchTimeMs, tookMs)
+    {
+        GroupedHits = groupedHits;
+    }
 }
 
 public record MultiSearchResult
 {
     public IEnumerable<SearchResult<object>> SearchResults { get; init; }
 
+    [JsonConstructor]
     public MultiSearchResult(IEnumerable<SearchResult<object>> searchResults)
     {
         SearchResults = searchResults;

--- a/src/Typesense/SearchResult.cs
+++ b/src/Typesense/SearchResult.cs
@@ -116,7 +116,16 @@ public record FacetStats
     }
 }
 
-public record SearchResult<T>
+public record GroupedHit<T>
+{
+    [JsonPropertyName("group_key")]
+    public IReadOnlyList<string> GroupKey { get; init; }
+    
+    [JsonPropertyName("hits")]
+    public IReadOnlyList<Hit<T>> Hits { get; init; }
+}
+
+public abstract record SearchResultBase
 {
     [JsonPropertyName("facet_counts")]
     public IReadOnlyCollection<FacetCount> FacetCounts { get; init; }
@@ -128,28 +137,22 @@ public record SearchResult<T>
     public int Page { get; init; }
     [JsonPropertyName("search_time_ms")]
     public int SearchTimeMs { get; init; }
-    [JsonPropertyName("hits")]
-    public IReadOnlyList<Hit<T>> Hits { get; init; }
+
     [JsonPropertyName("took_ms")]
     [Obsolete("Obsolete since version v0.18.0 use SearchTimeMs instead.")]
     public int? TookMs { get; init; }
+}
 
-    [JsonConstructor]
-    public SearchResult(
-        IReadOnlyCollection<FacetCount> facetCounts,
-        int found,
-        int outOf,
-        int page,
-        int searchTimeMs,
-        IReadOnlyList<Hit<T>> hits)
-    {
-        FacetCounts = facetCounts;
-        Found = found;
-        OutOf = outOf;
-        Page = page;
-        SearchTimeMs = searchTimeMs;
-        Hits = hits;
-    }
+public record SearchResult<T> : SearchResultBase
+{
+    [JsonPropertyName("hits")]
+    public IReadOnlyList<Hit<T>> Hits { get; init; }
+}
+
+public record GroupedSearchResult<T> : SearchResultBase
+{
+    [JsonPropertyName("grouped_hits")]
+    public IReadOnlyList<GroupedHit<T>> GroupedHits { get; init; }
 }
 
 public record MultiSearchResult

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -83,17 +83,12 @@ public class TypesenseClient : ITypesenseClient
 
     public async Task<SearchResult<T>> Search<T>(string collection, SearchParameters searchParameters)
     {
-        if (searchParameters?.GroupBy is not null)
-        {
-            await Console.Out.WriteLineAsync($"[Typesense-Dotnet] Using GroupBy with {nameof(Search)} which does not expose the grouped results. Use {nameof(SearchGrouped)} instead!");
-        }
-
         return await SearchInternal<SearchResult<T>>(collection, searchParameters);
     }
 
-    public async Task<GroupedSearchResult<T>> SearchGrouped<T>(string collection, SearchParameters searchParameters)
+    public async Task<SearchGroupedResult<T>> SearchGrouped<T>(string collection, GroupedSearchParameters groupedSearchParameters)
     {
-        return await SearchInternal<GroupedSearchResult<T>>(collection, searchParameters);
+        return await SearchInternal<SearchGroupedResult<T>>(collection, groupedSearchParameters);
     }
 
     public async Task<SearchResult<T>> MultiSearch<T>(MultiSearchParameters s1)
@@ -482,8 +477,6 @@ public class TypesenseClient : ITypesenseClient
             urlParameters += $"&page={searchParameters.Page}";
         if (searchParameters.PerPage is not null)
             urlParameters += $"&per_page={searchParameters.PerPage}";
-        if (searchParameters.GroupBy is not null)
-            urlParameters += $"&group_by={searchParameters.GroupBy}";
         if (searchParameters.GroupLimit is not null)
             urlParameters += $"&group_limit={searchParameters.GroupLimit}";
         if (searchParameters.IncludeFields is not null)
@@ -520,6 +513,8 @@ public class TypesenseClient : ITypesenseClient
             urlParameters += $"&facet_query_num_typos={searchParameters.FacetQueryNumberTypos.Value.ToString().ToLowerInvariant()}";
         if (searchParameters.Infix is not null)
             urlParameters += $"&infix={searchParameters.Infix}";
+        if (searchParameters is GroupedSearchParameters)
+            urlParameters += $"&group_by={((GroupedSearchParameters)searchParameters).GroupBy}";
 
         return urlParameters;
     }

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -1,9 +1,11 @@
+using System;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Typesense.Tests;
@@ -759,6 +761,21 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         {
             response.FacetCounts.Should().HaveCount(1);
             response.FacetCounts.First().Should().BeEquivalentTo(expected);
+        }
+    }
+
+    [Fact, TestPriority(11)]
+    public async Task Search_grouped_by_country()
+    {
+        var query = new SearchParameters("Stark", "company_name")
+            { GroupBy = "country" };
+        var response = await _client.SearchGrouped<Company>("companies", query);
+
+        using (var scope = new AssertionScope())
+        {
+            response.GroupedHits.Should().NotBeEmpty();
+            var firstHit = response.GroupedHits.First();
+            firstHit.GroupKey.Should().BeEquivalentTo("USA");
         }
     }
 

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -1,11 +1,9 @@
-using System;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Typesense.Tests;
@@ -767,8 +765,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
     [Fact, TestPriority(11)]
     public async Task Search_grouped_by_country()
     {
-        var query = new SearchParameters("Stark", "company_name")
-            { GroupBy = "country" };
+        var query = new GroupedSearchParameters("Stark", "company_name", "country");
         var response = await _client.SearchGrouped<Company>("companies", query);
 
         using (var scope = new AssertionScope())


### PR DESCRIPTION
This PR adds a handful of lines to support the output of grouped hits following https://typesense.org/docs/0.23.1/api/search.html#group-results

This might need some additional work because only one of Hit and GroupedHits will be present in the response. So to be closer to the API, it might make sense to either make both nullable (that would be a breaking change, I suppose?) or make a dedicated function to handle grouped searches that returns a separate type for them?

I am down with any of the options (including leaving it as is now); let me know what works for you!