### PR TITLE
Fix group key type and move GroupLimit to GroupedSearchParameters

### DIFF
--- a/src/Typesense/Converter/GroupKeyConverter.cs
+++ b/src/Typesense/Converter/GroupKeyConverter.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Typesense.Converter;
+
+public class GroupKeyConverter : JsonConverter<IReadOnlyList<string>>
+{
+    public override IReadOnlyList<string>? Read(ref Utf8JsonReader reader, Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        var jsonDocument = JsonDocument.ParseValue(ref reader);
+
+        return jsonDocument.RootElement.EnumerateArray().Select(StringifyJsonElement).ToList();
+    }
+
+    private static string StringifyJsonElement(JsonElement element)
+    {
+        var elementValue = element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.False => "false",
+            JsonValueKind.True => "true",
+            JsonValueKind.Number => element.GetDecimal().ToString(CultureInfo.CreateSpecificCulture("en-US")),
+            JsonValueKind.Array => string.Join(", ", element.EnumerateArray().Select(StringifyJsonElement)),
+            _ => null
+        };
+
+        if (elementValue is null)
+            throw new InvalidOperationException($"{nameof(elementValue)} being null is invalid.");
+
+        return elementValue;
+    }
+    
+    public override void Write(Utf8JsonWriter writer, IReadOnlyList<string> value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, value);
+    }
+}

--- a/src/Typesense/SearchParameters.cs
+++ b/src/Typesense/SearchParameters.cs
@@ -117,13 +117,6 @@ public record SearchParameters
     public string? PerPage { get; set; }
 
     /// <summary>
-    /// Maximum number of hits to be returned for every group. If the `group_limit` is
-    /// set as `K` then only the top K hits in each group are returned in the response.
-    /// </summary>
-    [JsonPropertyName("group_limit")]
-    public string? GroupLimit { get; set; }
-
-    /// <summary>
     /// List of fields from the document to include in the search result.
     /// </summary>
     [JsonPropertyName("include_fields")]
@@ -284,6 +277,13 @@ public record GroupedSearchParameters : SearchParameters
     /// </summary>
     [JsonPropertyName("group_by")]
     public string GroupBy { get; set; }
+    
+    /// <summary>
+    /// Maximum number of hits to be returned for every group. If the `group_limit` is
+    /// set as `K` then only the top K hits in each group are returned in the response.
+    /// </summary>
+    [JsonPropertyName("group_limit")]
+    public string? GroupLimit { get; set; }
 
     public GroupedSearchParameters(
         string text,

--- a/src/Typesense/SearchResult.cs
+++ b/src/Typesense/SearchResult.cs
@@ -119,13 +119,13 @@ public record FacetStats
 public record GroupedHit<T>
 {
     [JsonPropertyName("group_key")]
-    public IReadOnlyList<string> GroupKey { get; init; }
+    public IReadOnlyList<object> GroupKey { get; init; }
 
     [JsonPropertyName("hits")]
     public IReadOnlyList<Hit<T>> Hits { get; init; }
 
     [JsonConstructor]
-    public GroupedHit(IReadOnlyList<string> groupKey, IReadOnlyList<Hit<T>> hits)
+    public GroupedHit(IReadOnlyList<object> groupKey, IReadOnlyList<Hit<T>> hits)
     {
         GroupKey = groupKey;
         Hits = hits;

--- a/src/Typesense/SearchResult.cs
+++ b/src/Typesense/SearchResult.cs
@@ -119,13 +119,14 @@ public record FacetStats
 public record GroupedHit<T>
 {
     [JsonPropertyName("group_key")]
-    public IReadOnlyList<object> GroupKey { get; init; }
+    [JsonConverter(typeof(GroupKeyConverter))]
+    public IReadOnlyList<string> GroupKey { get; init; }
 
     [JsonPropertyName("hits")]
     public IReadOnlyList<Hit<T>> Hits { get; init; }
 
     [JsonConstructor]
-    public GroupedHit(IReadOnlyList<object> groupKey, IReadOnlyList<Hit<T>> hits)
+    public GroupedHit(IReadOnlyList<string> groupKey, IReadOnlyList<Hit<T>> hits)
     {
         GroupKey = groupKey;
         Hits = hits;

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -477,8 +477,6 @@ public class TypesenseClient : ITypesenseClient
             urlParameters += $"&page={searchParameters.Page}";
         if (searchParameters.PerPage is not null)
             urlParameters += $"&per_page={searchParameters.PerPage}";
-        if (searchParameters.GroupLimit is not null)
-            urlParameters += $"&group_limit={searchParameters.GroupLimit}";
         if (searchParameters.IncludeFields is not null)
             urlParameters += $"&include_fields={searchParameters.IncludeFields}";
         if (searchParameters.HighlightFullFields is not null)
@@ -513,8 +511,16 @@ public class TypesenseClient : ITypesenseClient
             urlParameters += $"&facet_query_num_typos={searchParameters.FacetQueryNumberTypos.Value.ToString().ToLowerInvariant()}";
         if (searchParameters.Infix is not null)
             urlParameters += $"&infix={searchParameters.Infix}";
-        if (searchParameters is GroupedSearchParameters)
-            urlParameters += $"&group_by={((GroupedSearchParameters)searchParameters).GroupBy}";
+
+        if (searchParameters is GroupedSearchParameters groupedSearchParameters)
+        {
+            urlParameters += $"&group_by={groupedSearchParameters.GroupBy}";
+            if (groupedSearchParameters.GroupLimit is not null)
+            {
+                urlParameters += $"&group_limit={groupedSearchParameters.GroupLimit}";
+            }
+        }
+
 
         return urlParameters;
     }

--- a/test/Typesense.Tests/TypesenseConverterTests.cs
+++ b/test/Typesense.Tests/TypesenseConverterTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using FluentAssertions.Execution;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -48,6 +49,33 @@ public class TypesenseConverterTests
             response[0].MatchedTokens[0].Should().BeOfType<List<string>>();
             response[1].MatchedTokens.Count.Should().Be(1);
             response[1].MatchedTokens[0].Should().BeOfType<string>();
+        }
+    }
+
+    [Fact]
+    public void TestGroupKeys()
+    {
+        var json = @"
+        {
+          ""group_key"": [""USA"", 12, 4.2, [""foo"", ""bar""], [42, 4.5]],
+          ""Hits"": []
+        }
+        ";
+
+        var groupedHit = JsonSerializer.Deserialize<GroupedHit<string>>(json);
+
+        using (new AssertionScope())
+        {
+            groupedHit.Should().NotBeNull();
+
+            var key = groupedHit.GroupKey;
+            key.Count.Should().Be(5);
+
+            key[0].Should().Be("USA");
+            key[1].Should().Be("12");
+            key[2].Should().Be("4.2");
+            key[3].Should().Be("foo, bar");
+            key[4].Should().Be("42, 4.5");
         }
     }
 }


### PR DESCRIPTION
I had to painfully discover this morning that the API may also send ints back in the GroupKey crashing the JSON deserialization so I changed the type to `IReadOnlyList<object>`.

I also took the liberty to move the `GroupLimit` parameter to the GroupedSearchParameters; I'd argue similarly to the GroupBy change, that this should not be breaking, since the parameter had no effect prior to 4.7.0 anyway and after 4.7.0 has no effect unless used with GroupedSearchParameters.