### PR TITLE
fix split join tokens sending invalid type bool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
       auth:
         username: $DOCKER_LOGIN
         password: $DOCKER_ACCESSTOKEN
-    - image: typesense/typesense:0.23.0 # For integration testing
+    - image: typesense/typesense:0.23.1 # For integration testing
       auth:
         username: $DOCKER_LOGIN
         password: $DOCKER_ACCESSTOKEN

--- a/README.md
+++ b/README.md
@@ -354,5 +354,5 @@ dotnet test --filter Category=Integration
 To enable running integration tests you can run Typesense in a docker container using the command below.
 
 ```sh
-docker run -p 8108:8108 -v/tmp/data:/data typesense/typesense:0.23.0 --data-dir /data --api-key=key
+docker run -p 8108:8108 -v/tmp/data:/data typesense/typesense:0.23.1 --data-dir /data --api-key=key
 ```

--- a/src/Typesense/SearchParameters.cs
+++ b/src/Typesense/SearchParameters.cs
@@ -3,6 +3,13 @@ using System.Text.Json.Serialization;
 
 namespace Typesense;
 
+public enum SplitJoinTokenOption
+{
+    Fallback,
+    Always,
+    Off
+}
+
 public record MultiSearchParameters : SearchParameters
 {
     /// <summary>
@@ -230,7 +237,7 @@ public record SearchParameters
     /// Treat space as typo: search for q=basket ball if q=basketball is not found or vice-versa.
     /// </summary>
     [JsonPropertyName("split_join_tokens")]
-    public bool? SplitJoinTokens { get; set; }
+    public SplitJoinTokenOption? SplitJoinTokens { get; set; }
 
     /// <summary>
     /// If you have some overrides defined but want to disable all of them during
@@ -285,7 +292,7 @@ public record GroupedSearchParameters : SearchParameters
     /// </summary>
     [JsonPropertyName("group_by")]
     public string GroupBy { get; set; }
-    
+
     /// <summary>
     /// Maximum number of hits to be returned for every group. If the `group_limit` is
     /// set as `K` then only the top K hits in each group are returned in the response.

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -504,7 +504,17 @@ public class TypesenseClient : ITypesenseClient
         if (searchParameters.EnableOverrides is not null)
             urlParameters += $"&enable_overrides={searchParameters.EnableOverrides.Value.ToString().ToLowerInvariant()}";
         if (searchParameters.SplitJoinTokens is not null)
-            urlParameters += $"&split_join_tokens={searchParameters.SplitJoinTokens.Value.ToString().ToLowerInvariant()}";
+        {
+            var splitJoinTokensStringRepresentation = searchParameters.SplitJoinTokens switch
+            {
+                SplitJoinTokenOption.Fallback => "fallback",
+                SplitJoinTokenOption.Always => "always",
+                SplitJoinTokenOption.Off => "off",
+                _ => throw new ArgumentException($"Cannot handle value {searchParameters.SplitJoinTokens}")
+            };
+
+            urlParameters += $"&split_join_tokens={splitJoinTokensStringRepresentation}";
+        }
         if (searchParameters.MaxCandiates is not null)
             urlParameters += $"&max_candidates={searchParameters.MaxCandiates.Value.ToString().ToLowerInvariant()}";
         if (searchParameters.FacetQueryNumberTypos is not null)

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -670,6 +670,32 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
     }
 
     [Fact, TestPriority(11)]
+    public async Task Search_query_by_just_text_with_split_join_tokens_set()
+    {
+        var expected = new Company
+        {
+            Id = "124",
+            CompanyName = "Stark Industries",
+            NumEmployees = 6000,
+            Country = "USA",
+        };
+
+        var query = new SearchParameters("Stark", "company_name")
+        {
+            SplitJoinTokens = SplitJoinTokenOption.Fallback
+        };
+
+        var response = await _client.Search<Company>("companies", query);
+
+        using (var scope = new AssertionScope())
+        {
+            response.Found.Should().Be(1);
+            response.Hits.First().Document.Should().BeEquivalentTo(expected);
+        }
+    }
+
+
+    [Fact, TestPriority(11)]
     public async Task Search_query_by_two_fields()
     {
         var expected = new Company


### PR DESCRIPTION
fixes https://github.com/DAXGRID/typesense-dotnet/issues/107 #107

This is a breaking change, but to match the undocumented change form 0.23.0 to 0.23.1 this has to be done to be compatible with Typesense going forward.