### PR TITLE
fields now matches order in docs to easier add new fields

### DIFF
--- a/src/Typesense/FieldType.cs
+++ b/src/Typesense/FieldType.cs
@@ -6,30 +6,43 @@ public enum FieldType
 {
     [EnumMember(Value = "string")]
     String,
-    [EnumMember(Value = "int32")]
-    Int32,
-    [EnumMember(Value = "int64")]
-    Int64,
-    [EnumMember(Value = "float")]
-    Float,
-    [EnumMember(Value = "bool")]
-    Bool,
-    [EnumMember(Value = "geopoint")]
-    GeoPoint,
+
     [EnumMember(Value = "string[]")]
     StringArray,
+
+    [EnumMember(Value = "int32")]
+    Int32,
+
     [EnumMember(Value = "int32[]")]
     Int32Array,
+
+    [EnumMember(Value = "int64")]
+    Int64,
+
     [EnumMember(Value = "int64[]")]
     Int64Array,
+
+    [EnumMember(Value = "float")]
+    Float,
+
     [EnumMember(Value = "float[]")]
     FloatArray,
+
+    [EnumMember(Value = "bool")]
+    Bool,
+
     [EnumMember(Value = "bool[]")]
     BoolArray,
+
+    [EnumMember(Value = "geopoint")]
+    GeoPoint,
+
     [EnumMember(Value = "geopoint[]")]
     GeoPointArray,
-    [EnumMember(Value = "auto")]
-    Auto,
+
     [EnumMember(Value = "string*")]
     AutoString,
+
+    [EnumMember(Value = "auto")]
+    Auto,
 }


### PR DESCRIPTION
Now matches the order in the documentation. This can simplify spotting missing field types in the future.

https://typesense.org/docs/0.24.0/api/collections.html#field-types