### PR TITLE
facet is no longer a required field in constructor for `Field`

### DIFF
--- a/src/Typesense/Field.cs
+++ b/src/Typesense/Field.cs
@@ -14,7 +14,7 @@ public record Field
     public FieldType Type { get; init; }
 
     [JsonPropertyName("facet")]
-    public bool Facet { get; init; }
+    public bool? Facet { get; init; }
 
     [JsonPropertyName("optional")]
     public bool? Optional { get; init; }
@@ -43,14 +43,14 @@ public record Field
         Type = type;
     }
 
-    public Field(string name, FieldType type, bool facet)
+    public Field(string name, FieldType type, bool? facet)
     {
         Name = name;
         Type = type;
         Facet = facet;
     }
 
-    public Field(string name, FieldType type, bool facet, bool? optional)
+    public Field(string name, FieldType type, bool? facet, bool? optional)
     {
         Name = name;
         Type = type;
@@ -58,7 +58,7 @@ public record Field
         Optional = optional;
     }
 
-    public Field(string name, FieldType type, bool facet, bool? optional, bool? index)
+    public Field(string name, FieldType type, bool? facet, bool? optional, bool? index)
     {
         Name = name;
         Type = type;
@@ -69,7 +69,7 @@ public record Field
 
     public Field(string name,
                  FieldType type,
-                 bool facet,
+                 bool? facet,
                  bool? optional,
                  bool? index,
                  bool? sort)
@@ -84,7 +84,7 @@ public record Field
 
     public Field(string name,
                  FieldType type,
-                 bool facet,
+                 bool? facet,
                  bool? optional,
                  bool? index,
                  bool? sort,
@@ -102,7 +102,7 @@ public record Field
     [JsonConstructor]
     public Field(string name,
                  FieldType type,
-                 bool facet,
+                 bool? facet,
                  bool? optional,
                  bool? index,
                  bool? sort,
@@ -120,7 +120,7 @@ public record Field
     }
 
     [Obsolete("A better choice going forward is using the constructor with 'FieldType' enum instead.")]
-    public Field(string name, string type, bool facet, bool optional = false, bool index = true)
+    public Field(string name, string type, bool? facet, bool optional = false, bool index = true)
     {
         Name = name;
         Type = MapFieldType(type);

--- a/src/Typesense/UpdateSchema.cs
+++ b/src/Typesense/UpdateSchema.cs
@@ -19,32 +19,32 @@ public record UpdateSchemaField : Field
     public UpdateSchemaField(
         string name,
         FieldType type,
-        bool facet) : base(name, type, facet) { }
+        bool? facet) : base(name, type, facet) { }
 
     public UpdateSchemaField(
         string name,
         FieldType type,
-        bool facet,
+        bool? facet,
         bool? optional) : base(name, type, facet, optional) { }
 
     public UpdateSchemaField(
         string name,
         FieldType type,
-        bool facet,
+        bool? facet,
         bool? optional,
         bool? index) : base(name, type, facet, optional, index) { }
 
     public UpdateSchemaField(
         string name,
         FieldType type,
-        bool facet,
+        bool? facet,
         bool? optional,
         bool? index, bool? sort) : base(name, type, facet, optional, index, sort) { }
 
     public UpdateSchemaField(
         string name,
         FieldType type,
-        bool facet,
+        bool? facet,
         bool? optional,
         bool? index,
         bool? sort,
@@ -54,7 +54,7 @@ public record UpdateSchemaField : Field
     public UpdateSchemaField(
         string name,
         FieldType type,
-        bool facet,
+        bool? facet,
         bool? optional,
         bool? index,
         bool? sort,


### PR DESCRIPTION
The boolean field `Facet` is no longer required doing initialization of the `Field` type. The Typesense API will automatically set it to `false`, if no value is send in the request.

Doing it this way is cleaner and follows the API specification.