### PR TITLE
optional constructor params are now default to simplify creation

### DIFF
--- a/src/Typesense/Field.cs
+++ b/src/Typesense/Field.cs
@@ -43,14 +43,14 @@ public record Field
         Type = type;
     }
 
-    public Field(string name, FieldType type, bool? facet)
+    public Field(string name, FieldType type, bool? facet = null)
     {
         Name = name;
         Type = type;
         Facet = facet;
     }
 
-    public Field(string name, FieldType type, bool? facet, bool? optional)
+    public Field(string name, FieldType type, bool? facet = null, bool? optional = null)
     {
         Name = name;
         Type = type;
@@ -58,7 +58,7 @@ public record Field
         Optional = optional;
     }
 
-    public Field(string name, FieldType type, bool? facet, bool? optional, bool? index)
+    public Field(string name, FieldType type, bool? facet = null, bool? optional = null, bool? index = null)
     {
         Name = name;
         Type = type;
@@ -69,10 +69,10 @@ public record Field
 
     public Field(string name,
                  FieldType type,
-                 bool? facet,
-                 bool? optional,
-                 bool? index,
-                 bool? sort)
+                 bool? facet = null,
+                 bool? optional = null,
+                 bool? index = null,
+                 bool? sort = null)
     {
         Name = name;
         Type = type;
@@ -84,11 +84,11 @@ public record Field
 
     public Field(string name,
                  FieldType type,
-                 bool? facet,
-                 bool? optional,
-                 bool? index,
-                 bool? sort,
-                 bool? infix)
+                 bool? facet = null,
+                 bool? optional = null,
+                 bool? index = null,
+                 bool? sort = null,
+                 bool? infix = null)
     {
         Name = name;
         Type = type;
@@ -102,12 +102,12 @@ public record Field
     [JsonConstructor]
     public Field(string name,
                  FieldType type,
-                 bool? facet,
-                 bool? optional,
-                 bool? index,
-                 bool? sort,
-                 bool? infix,
-                 string? locale)
+                 bool? facet = null,
+                 bool? optional = null,
+                 bool? index = null,
+                 bool? sort = null,
+                 bool? infix = null,
+                 string? locale = null)
     {
         Name = name;
         Type = type;

--- a/src/Typesense/UpdateSchema.cs
+++ b/src/Typesense/UpdateSchema.cs
@@ -19,58 +19,59 @@ public record UpdateSchemaField : Field
     public UpdateSchemaField(
         string name,
         FieldType type,
-        bool? facet) : base(name, type, facet) { }
+        bool? facet = null) : base(name, type, facet) { }
 
     public UpdateSchemaField(
         string name,
         FieldType type,
-        bool? facet,
-        bool? optional) : base(name, type, facet, optional) { }
+        bool? facet = null,
+        bool? optional = null) : base(name, type, facet, optional) { }
 
     public UpdateSchemaField(
         string name,
         FieldType type,
-        bool? facet,
-        bool? optional,
-        bool? index) : base(name, type, facet, optional, index) { }
+        bool? facet = null,
+        bool? optional = null,
+        bool? index = null) : base(name, type, facet, optional, index) { }
 
     public UpdateSchemaField(
         string name,
         FieldType type,
-        bool? facet,
-        bool? optional,
-        bool? index, bool? sort) : base(name, type, facet, optional, index, sort) { }
+        bool? facet = null,
+        bool? optional = null,
+        bool? index = null,
+        bool? sort = null) : base(name, type, facet, optional, index, sort) { }
 
     public UpdateSchemaField(
         string name,
         FieldType type,
-        bool? facet,
-        bool? optional,
-        bool? index,
-        bool? sort,
-        bool? infix) : base(name, type, facet, optional, index, sort, infix) { }
+        bool? facet = null,
+        bool? optional = null,
+        bool? index = null,
+        bool? sort = null,
+        bool? infix = null) : base(name, type, facet, optional, index, sort, infix) { }
 
     public UpdateSchemaField(
         string name,
         FieldType type,
-        bool? facet,
-        bool? optional,
-        bool? index,
-        bool? sort,
-        bool? infix,
-        string? locale) : base(name, type, facet, optional, index, sort, infix, locale) { }
+        bool? facet = null,
+        bool? optional = null,
+        bool? index = null,
+        bool? sort = null,
+        bool? infix = null,
+        string? locale = null) : base(name, type, facet, optional, index, sort, infix, locale) { }
 
     [JsonConstructor]
     public UpdateSchemaField(
         string name,
         FieldType type,
-        bool? facet,
-        bool? optional,
-        bool? index,
-        bool? sort,
-        bool? infix,
-        string? locale,
-        bool? drop) : base(name, type, facet, optional, index, sort, infix, locale)
+        bool? facet = null,
+        bool? optional = null,
+        bool? index = null,
+        bool? sort = null,
+        bool? infix = null,
+        string? locale = null,
+        bool? drop = null) : base(name, type, facet, optional, index, sort, infix, locale)
     {
         Drop = drop;
     }

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -240,12 +240,8 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new Field(
                     "name",
                     FieldType.String,
-                    false,
-                    true,
-                    null,
-                    null,
-                    null,
-                    "zh"),
+                    optional: true,
+                    locale: "zh"),
             });
 
         var response = await _client.CreateCollection(schema);


### PR DESCRIPTION
This makes for a cleaner API, so users now only have to specify the constructor parameters they want to use.