### PR TITLE
can now execute vector queries

### DIFF
--- a/src/Typesense/Converter/VectorQueryConverter.cs
+++ b/src/Typesense/Converter/VectorQueryConverter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Typesense.Converter;
+
+public class VectorQueryJsonConverter : JsonConverter<VectorQuery>
+{
+    public override bool CanConvert(Type typeToConvert)
+    {
+        return typeToConvert == typeof(VectorQuery);
+    }
+
+    public override VectorQuery Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var jsonValue = reader.GetString() ?? string.Empty;
+        return !String.IsNullOrEmpty(jsonValue) ? new VectorQuery(jsonValue) : null!;
+    }
+
+    public override void Write(Utf8JsonWriter writer, VectorQuery value, JsonSerializerOptions options)
+    {
+        if (writer is null)
+            throw new ArgumentNullException(nameof(writer));
+
+        if (value is null)
+            throw new ArgumentNullException(nameof(value));
+
+        writer.WriteStringValue(value.ToQuery());
+    }
+}

--- a/src/Typesense/Field.cs
+++ b/src/Typesense/Field.cs
@@ -31,6 +31,9 @@ public record Field
     [JsonPropertyName("locale")]
     public string? Locale { get; init; }
 
+    [JsonPropertyName("num_dim")]
+    public int? NumberOfDimensions { get; init; }
+
     // This constructor is made to handle inherited classes.
     protected Field(string name)
     {
@@ -41,6 +44,13 @@ public record Field
     {
         Name = name;
         Type = type;
+    }
+
+    public Field(string name, FieldType type, int numberOfDimensions)
+    {
+        Name = name;
+        Type = type;
+        NumberOfDimensions = numberOfDimensions;
     }
 
     public Field(string name, FieldType type, bool? facet = null)

--- a/src/Typesense/SearchParameters.cs
+++ b/src/Typesense/SearchParameters.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.Json.Serialization;
+using Typesense.Converter;
 
 namespace Typesense;
 
@@ -17,6 +18,11 @@ public record MultiSearchParameters : SearchParameters
     /// </summary>
     [JsonPropertyName("collection")]
     public string Collection { get; set; }
+
+    public MultiSearchParameters(string collection, string text) : base(text)
+    {
+        Collection = collection;
+    }
 
     public MultiSearchParameters(string collection, string text, string queryBy) : base(text, queryBy)
     {
@@ -42,7 +48,7 @@ public record SearchParameters
     /// A list of `string` fields that should be queried against. Multiple fields are separated with a comma.
     /// </summary>
     [JsonPropertyName("query_by")]
-    public string QueryBy { get; set; }
+    public string? QueryBy { get; set; }
 
     /// <summary>
     /// Boolean field to indicate that the last word in the query should
@@ -354,11 +360,26 @@ public record SearchParameters
     [JsonPropertyName("cache_ttl")]
     public int? CacheTtl { get; set; }
 
+    // ---------------------------------------------------------------------------------------
+    // Vector Search - https://typesense.org/docs/0.24.1/api/vector-search.html#what-is-an-embedding
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Query-string for vector searches.
+    /// </summary>
+    [JsonConverter(typeof(VectorQueryJsonConverter)), JsonPropertyName("vector_query")]
+    public VectorQuery? VectorQuery { get; init; }
+
     [Obsolete("Use multi-arity constructor instead.")]
     public SearchParameters()
     {
         Text = string.Empty;
         QueryBy = string.Empty;
+    }
+
+    public SearchParameters(string text)
+    {
+        Text = text;
     }
 
     public SearchParameters(string text, string queryBy)

--- a/src/Typesense/SearchResult.cs
+++ b/src/Typesense/SearchResult.cs
@@ -53,13 +53,18 @@ public record Hit<T>
     public T Document { get; init; }
 
     [JsonPropertyName("text_match")]
-    public long TextMatch { get; init; }
+    public long? TextMatch { get; init; }
 
-    public Hit(IReadOnlyList<Highlight> highlights, T document, long textMatch)
+    [JsonPropertyName("vector_distance")]
+    public double? VectorDistance { get; init; }
+
+    [JsonConstructor]
+    public Hit(IReadOnlyList<Highlight> highlights, T document, long? textMatch, double? vectorDistance)
     {
         Highlights = highlights;
         Document = document;
         TextMatch = textMatch;
+        VectorDistance = vectorDistance;
     }
 }
 

--- a/src/Typesense/VectorSearchQuery.cs
+++ b/src/Typesense/VectorSearchQuery.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Typesense;
+
+/// <summary>
+/// Encapsulates the vector query function utilized by Typesense.
+/// Examples:
+/// vec:([0.34, 0.66, 0.12, 0.68], k: 10)
+/// vec:([0.34, 0.66, 0.12, 0.68], k: 10, flat_search_cutoff: 20)
+/// vec:([], id: abcd)
+/// </summary>
+public record VectorQuery
+{
+    private float[] _vector = Array.Empty<float>();
+
+    /// <summary>
+    /// Document vector.
+    /// </summary>
+    // We only expose `ReadOnlyCollection` to make sure the consumer cannot modify the underlying value.
+    public ReadOnlyCollection<float> Vector => new(_vector);
+
+    /// <summary>
+    /// Document Id.
+    /// </summary>
+    public string? Id { get; private set; }
+
+    /// <summary>
+    /// Number of documents to return.
+    /// </summary>
+    public int? K { get; private set; }
+
+    /// <summary>
+    /// Allows bypass of the HNSW index to do a flat / brute-force ranking of vectors
+    /// </summary>
+    public int? FlatSearchCutoff { get; private set; }
+
+    /// <summary>
+    /// Extra parameters to include in the query.
+    /// </summary>
+    public Dictionary<string, string> ExtraParams { get; private set; }
+
+    /// <summary>
+    /// Initialize VectorQuery using a raw query.
+    /// </summary>
+    /// <param name="query"></param>
+    public VectorQuery(string query)
+    {
+        ExtraParams = new();
+        ParseQuery(query);
+    }
+
+    /// <summary>
+    /// Initialize VectorQuery.
+    /// </summary>
+    /// <param name="vector">Document vector</param>
+    /// <param name="id">String document id</param>
+    /// <param name="k">Number of documents that are returned</param>
+    /// <param name="flatSearchCutoff">If you wish to do brute-force vector search when a given query matches fewer than 20 documents, sending flat_search_cutoff=20 will bypass the HNSW index when the number of results found is less than 20</param>
+    /// <param name="extraParams">Any extra parameters you wish to include as a key/value dictionary</param>
+    /// <exception cref="ArgumentException"></exception>
+    public VectorQuery(float[] vector, string? id = null, int? k = null, int? flatSearchCutoff = null, Dictionary<string, string>? extraParams = null)
+    {
+        if (vector is null)
+            throw new ArgumentNullException(nameof(vector));
+
+        if (vector.Length > 0 && id != null)
+            throw new ArgumentException(
+                "Malformed vector query string: cannot pass both vector query and `id` parameter.");
+
+        if (vector.Length == 0 && id is null)
+            throw new ArgumentException("When a vector query value is empty, an `id` parameter must be present.");
+
+        _vector = vector;
+        Id = id;
+        K = k;
+        FlatSearchCutoff = flatSearchCutoff;
+        ExtraParams = extraParams ?? new();
+    }
+
+    /// <summary>
+    /// Parses a query and initializes the related object members.
+    /// </summary>
+    /// <param name="query"></param>
+    /// <exception cref="ArgumentException"></exception>
+    private void ParseQuery(string query)
+    {
+        // First parse the portion of the string inside the vec property - "vec:([0.96826, 0.94, 0.39557, 0.306488], k:100, flat_search_cutoff: 20)"
+        var pattern = @"vec:\((\[.*?\])(\s*,[^)]+)*\)";
+
+        var match = Regex.Match(query, pattern);
+        if (!match.Success)
+            throw new ArgumentException("Malformed vector query string.");
+
+        // Since the first parameter MUST be the array of floats this is a quick check to see if it is well-formatted
+        var first = match.Groups[1].Value;
+        first = first.Substring(1, first.Length - 2);
+
+        if (!String.IsNullOrEmpty(first))
+        {
+            // Get the float array query portion
+            _vector = first
+                .Split(",")
+                .Select(x =>
+                {
+                    if (!float.TryParse(x.Trim(), out float result))
+                        throw new ArgumentException(
+                            "Malformed vector query string: one of the vector values is not a float.");
+
+                    return result;
+                }).ToArray();
+        }
+
+        // Commas are always used as a delimiter inside the list of parameters
+        var qParams = match.Groups[2].Value
+            .Split(",")
+            .Select(x => x.Trim())
+            .Where(x => !string.IsNullOrEmpty(x))
+            .ToList();
+
+        foreach (var param in qParams)
+        {
+            var kvp = param.Split(':').Select(x => x.Trim()).ToArray();
+
+            if (kvp.Length != 2)
+                throw new ArgumentException($"Malformed vector query string at parameter '{param}'");
+
+            switch (kvp[0])
+            {
+                case "id":
+                    if (_vector.Length > 0)
+                        throw new ArgumentException(
+                            "Malformed vector query string: cannot pass both vector query and `id` parameter.");
+
+                    Id = kvp[1];
+                    break;
+
+                case "k":
+                    if (!Int32.TryParse(kvp[1], out int k))
+                        throw new ArgumentException("Malformed vector query string: k value is not an integer");
+
+                    K = k;
+                    break;
+
+                case "flat_search_cutoff":
+                    if (!Int32.TryParse(kvp[1], out int flatSearchCutoff))
+                        throw new ArgumentException("Malformed vector query string: flat_search_cutoff value is not an integer");
+
+                    FlatSearchCutoff = flatSearchCutoff;
+                    break;
+
+                default:
+                    ExtraParams.Add(kvp[0], kvp[1]);
+                    break;
+            }
+        }
+
+        if (_vector.Length == 0 && Id is null)
+            throw new ArgumentException("When a vector query value is empty, an `id` parameter must be present.");
+    }
+
+    /// <summary>
+    /// Convert this vector query into a query useable by Typesense.
+    /// </summary>
+    /// <returns>The vector-search query string.</returns>
+    public virtual string ToQuery()
+    {
+        var qParams = new List<string>();
+
+        // Float vector is required, even if empty
+        var qry = string.Join(",", _vector);
+        qParams.Add($"[{qry}]");
+
+        // All other parameters are optional
+        if (Id != null)
+            qParams.Add($"id:{Id}");
+
+        if (K != null)
+            qParams.Add($"k:{K}");
+
+        if (FlatSearchCutoff != null)
+            qParams.Add($"flat_search_cutoff:{FlatSearchCutoff}");
+
+        // Allow for additional parameters if provided
+        qParams.AddRange(ExtraParams.Select(kvp => $"{kvp.Key}:{kvp.Value}"));
+
+        // Build the final query - note that the only delimiter for all type/value pairs is a comma and there is no
+        // need to surround string values with quotations
+        var query = string.Join(",", qParams);
+
+        return $"vec:({query})";
+    }
+}

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -3,11 +3,21 @@ using FluentAssertions.Execution;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Typesense.Tests;
+
+// The `AddressVectorSearch` type is created to test vector search functionality in Typesense.
+public record AddressVectorSearch
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; }
+    [JsonPropertyName("vec")]
+    public float[] Vec { get; init; }
+}
 
 public record Location
 {
@@ -1610,6 +1620,102 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         {
             response.Found.Should().Be(1);
             response.Hits.First().Document.Should().BeEquivalentTo(company);
+        }
+    }
+
+    [Fact, TestPriority(32)]
+    public async Task Can_do_vector_search()
+    {
+        const string COLLECTION_NAME = "address_vector_search";
+
+        try
+        {
+            var schema = new Schema(
+                COLLECTION_NAME,
+                new List<Field>
+                {
+                    new Field("vec", FieldType.FloatArray, 4)
+                });
+
+            _ = await _client.CreateCollection(schema);
+
+            await _client.CreateDocument(
+                COLLECTION_NAME,
+                new AddressVectorSearch()
+                {
+                    Id = "0",
+                    Vec = new float[] { 0.04F, 0.234F, 0.113F, 0.001F }
+                });
+
+            // We want to make sure the query works using the query object `VectorQuery`
+            var queryUsingQueryObject = new MultiSearchParameters(COLLECTION_NAME, "*")
+            {
+                // vec:([0.96826, 0.94, 0.39557, 0.306488], k:100)
+                VectorQuery = new(
+                    vector: new float[] { 0.96826F, 0.94F, 0.39557F, 0.306488F },
+                    k: 100)
+            };
+
+            // We want to make sure the query works using a query string
+            var queryUsingQueryString = new MultiSearchParameters(COLLECTION_NAME, "*")
+            {
+                // vec:([0.96826, 0.94, 0.39557, 0.306488], k:100)
+                VectorQuery = new("vec:([0.96826,0.94,0.39557,0.306488],k:100)")
+            };
+
+            var queryObjectResponse = await _client.MultiSearch<AddressVectorSearch>(queryUsingQueryObject);
+            var queryStringResponse = await _client.MultiSearch<AddressVectorSearch>(queryUsingQueryString);
+
+            using (var scope = new AssertionScope())
+            {
+                queryObjectResponse.Found.Should().Be(1);
+                queryObjectResponse.OutOf.Should().Be(1);
+                queryObjectResponse.Page.Should().Be(1);
+                queryObjectResponse.Hits.Count.Should().Be(1);
+                queryObjectResponse.Hits
+                    .First()
+                    .Should()
+                    .BeEquivalentTo(
+                        new Hit<AddressVectorSearch>(
+                            new List<Highlight>().AsReadOnly(),
+                            new AddressVectorSearch
+                            {
+                                Id = "0",
+                                Vec = new float[] { 0.04F, 0.234F, 0.113F, 0.001F }
+                            },
+                            null,
+                            0.19744956493377686));
+
+                queryStringResponse.Found.Should().Be(1);
+                queryStringResponse.OutOf.Should().Be(1);
+                queryStringResponse.Page.Should().Be(1);
+                queryStringResponse.Hits.Count.Should().Be(1);
+                queryStringResponse.Hits
+                    .First()
+                    .Should()
+                    .BeEquivalentTo(
+                        new Hit<AddressVectorSearch>(
+                            new List<Highlight>().AsReadOnly(),
+                            new AddressVectorSearch
+                            {
+                                Id = "0",
+                                Vec = new float[] { 0.04F, 0.234F, 0.113F, 0.001F }
+                            },
+                            null,
+                            0.19744956493377686));
+            }
+        }
+        finally
+        {
+            // Make sure that no matter what the collection is deleted.
+            try
+            {
+                _ = _client.DeleteCollection(COLLECTION_NAME);
+            }
+            catch (TypesenseApiNotFoundException)
+            {
+                //  Do nothing, it might have crashed before creating the collection.
+            }
         }
     }
 


### PR DESCRIPTION
Add support for vector queries, as requested in issue #145.

This shows an example of how to do nearest neighbor vector search. For now we decided on making the query a simple string, so the consumer of the API will have to build the `VectorQuery` themselves, but in the future we might make a helper function that can help making the query.

```csharp
const string COLLECTION_NAME = "address_vector_search";

var schema = new Schema(
    COLLECTION_NAME,
    new List<Field>
    {
        new Field("vec", FieldType.FloatArray, 4)
    });

_ = await _client.CreateCollection(schema);

await _client.CreateDocument(
    COLLECTION_NAME,
    new AddressVectorSearch()
    {
        Id = "0",
        Vec = new double[] { 0.04, 0.234, 0.113, 0.001 }
    });

var query = new SearchParameters("*")
{
    VectorQuery = "vec:([0.96826, 0.94, 0.39557, 0.306488], k:100)"
};

var response = await _client.Search<AddressVectorSearch>(COLLECTION_NAME, query);
```