### PR TITLE
Support Auto Embedding & Semantic Search

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
       auth:
         username: $DOCKER_LOGIN
         password: $DOCKER_ACCESSTOKEN
-    - image: typesense/typesense:0.24.1 # For integration testing
+    - image: typesense/typesense:0.25.0 # For integration testing
       auth:
         username: $DOCKER_LOGIN
         password: $DOCKER_ACCESSTOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
       auth:
         username: $DOCKER_LOGIN
         password: $DOCKER_ACCESSTOKEN
-    - image: typesense/typesense:0.25.0 # For integration testing
+    - image: typesense/typesense:0.25.1.rc2 # For integration testing
       auth:
         username: $DOCKER_LOGIN
         password: $DOCKER_ACCESSTOKEN

--- a/README.md
+++ b/README.md
@@ -422,5 +422,5 @@ To run integration tests, you can execute Typesense in a docker container by usi
 
 
 ```sh
-docker run -p 8108:8108 -v /tmp/data:/data typesense/typesense:0.25.0 --data-dir /data --api-key=key
+docker run -p 8108:8108 -v /tmp/data:/data typesense/typesense:0.25.1.rc2 --data-dir /data --api-key=key
 ```

--- a/README.md
+++ b/README.md
@@ -422,5 +422,5 @@ To run integration tests, you can execute Typesense in a docker container by usi
 
 
 ```sh
-docker run -p 8108:8108 -v /tmp/data:/data typesense/typesense:0.24.1 --data-dir /data --api-key=key
+docker run -p 8108:8108 -v /tmp/data:/data typesense/typesense:0.25.0 --data-dir /data --api-key=key
 ```

--- a/src/Typesense/AutoEmbeddingConfig.cs
+++ b/src/Typesense/AutoEmbeddingConfig.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.ObjectModel;
+using System.Text.Json.Serialization;
+
+namespace Typesense;
+
+public record AutoEmbeddingConfig
+{
+    [JsonPropertyName("from")]
+    public Collection<string> From { get; init; }
+
+    [JsonPropertyName("model_config")]
+    public ModelConfig ModelConfig { get; init; }
+
+    public AutoEmbeddingConfig(Collection<string> from, ModelConfig modelConfig)
+    {
+        From = from;
+        ModelConfig = modelConfig;
+    }
+}
+
+public record ModelConfig
+{
+    [JsonPropertyName("model_name")]
+    public string ModelName { get; init; }
+
+    [JsonPropertyName("api_key")]
+    public string? ApiKey { get; init; }
+
+    [JsonPropertyName("access_token")]
+    public string? AccessToken { get; init; }
+
+    [JsonPropertyName("refresh_token")]
+    public string? RefreshToken { get; init; }
+
+    [JsonPropertyName("client_id")]
+    public string? ClientId { get; init; }
+
+    [JsonPropertyName("client_secret")]
+    public string? ClientSecret { get; init; }
+
+    [JsonPropertyName("project_id")]
+    public string? ProjectId { get; init; }
+
+    [JsonPropertyName("indexing_prefix")]
+    public string? IndexingPrefix { get; init; }
+
+    [JsonPropertyName("query_prefix")]
+    public string? QueryPrefix { get; init; }
+
+    public ModelConfig(string modelName)
+    {
+        ModelName = modelName;
+    }
+}

--- a/src/Typesense/Field.cs
+++ b/src/Typesense/Field.cs
@@ -34,6 +34,9 @@ public record Field
     [JsonPropertyName("num_dim")]
     public int? NumberOfDimensions { get; init; }
 
+    [JsonPropertyName("embed")]
+    public AutoEmbeddingConfig? Embed { get; init; }
+
     // This constructor is made to handle inherited classes.
     protected Field(string name)
     {
@@ -51,6 +54,13 @@ public record Field
         Name = name;
         Type = type;
         NumberOfDimensions = numberOfDimensions;
+    }
+
+    public Field(string name, FieldType type, AutoEmbeddingConfig embed)
+    {
+        Name = name;
+        Type = type;
+        Embed = embed;
     }
 
     public Field(string name, FieldType type, bool? facet = null)

--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -320,6 +320,11 @@ public interface ITypesenseClient
     /// <param name="documents">A list of the documents to be imported. The whole string should be in JSON-newline format.</param>
     /// <param name="batchSize">The number of documents that should be imported - defaults to 40.</param>
     /// <param name="importType">The import type, can either be Create, Update or Upsert - defaults to Create.</param>
+    /// <param name="remoteEmbeddingBatchSize">
+    /// Max size of each batch that will be sent to remote APIs while importing multiple documents at once.
+    /// Using lower amount will lower timeout risk, but increase number of requests made.
+    /// If not specified, typesense server will default to 200.
+    /// </param>
     /// <returns>A collection of import responses.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
@@ -329,7 +334,12 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiConflictException"></exception>
     /// <exception cref="TypesenseApiUnprocessableEntityException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
-    Task<List<ImportResponse>> ImportDocuments<T>(string collection, string documents, int batchSize = 40, ImportType importType = ImportType.Create);
+    Task<List<ImportResponse>> ImportDocuments<T>(
+        string collection,
+        string documents,
+        int batchSize = 40,
+        ImportType importType = ImportType.Create,
+        int? remoteEmbeddingBatchSize = null);
 
     /// <summary>
     /// Batch import documents.
@@ -338,6 +348,11 @@ public interface ITypesenseClient
     /// <param name="documents">A list of the documents to be imported. Each document should be in JSON format.</param>
     /// <param name="batchSize">The number of documents that should be imported - defaults to 40.</param>
     /// <param name="importType">The import type, can either be Create, Update or Upsert - defaults to Create.</param>
+    /// <param name="remoteEmbeddingBatchSize">
+    /// Max size of each batch that will be sent to remote APIs while importing multiple documents at once.
+    /// Using lower amount will lower timeout risk, but increase number of requests made.
+    /// If not specified, typesense server will default to 200.
+    /// </param>
     /// <returns>A collection of import responses.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
@@ -347,7 +362,12 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiConflictException"></exception>
     /// <exception cref="TypesenseApiUnprocessableEntityException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
-    Task<List<ImportResponse>> ImportDocuments<T>(string collection, IEnumerable<string> documents, int batchSize = 40, ImportType importType = ImportType.Create);
+    Task<List<ImportResponse>> ImportDocuments<T>(
+        string collection,
+        IEnumerable<string> documents,
+        int batchSize = 40,
+        ImportType importType = ImportType.Create,
+        int? remoteEmbeddingBatchSize = null);
 
     /// <summary>
     /// Batch import documents.
@@ -356,6 +376,11 @@ public interface ITypesenseClient
     /// <param name="documents">A list of the documents to be imported.</param>
     /// <param name="batchSize">The number of documents that should be imported - defaults to 40.</param>
     /// <param name="importType">The import type, can either be Create, Update or Upsert - defaults to Create.</param>
+    /// <param name="remoteEmbeddingBatchSize">
+    /// Max size of each batch that will be sent to remote APIs while importing multiple documents at once.
+    /// Using lower amount will lower timeout risk, but increase number of requests made.
+    /// If not specified, typesense server will default to 200.
+    /// </param>
     /// <returns>A collection of import responses.</returns>
     /// <exception cref="ArgumentNullException"></exception>
     /// <exception cref="ArgumentException"></exception>
@@ -365,7 +390,12 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiConflictException"></exception>
     /// <exception cref="TypesenseApiUnprocessableEntityException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
-    Task<List<ImportResponse>> ImportDocuments<T>(string collection, IEnumerable<T> documents, int batchSize = 40, ImportType importType = ImportType.Create);
+    Task<List<ImportResponse>> ImportDocuments<T>(
+        string collection,
+        IEnumerable<T> documents,
+        int batchSize = 40,
+        ImportType importType = ImportType.Create,
+        int? remoteEmbeddingBatchSize = null);
 
     /// <summary>
     /// Export all documents in a given collection.

--- a/src/Typesense/SearchParameters.cs
+++ b/src/Typesense/SearchParameters.cs
@@ -370,6 +370,18 @@ public record SearchParameters
     [JsonPropertyName("cache_ttl")]
     public int? CacheTtl { get; set; }
 
+    /// <summary>
+    /// How long to wait until an API call to a remote embedding service is considered a timeout.
+    /// </summary>
+    [JsonPropertyName("remote_embedding_timeout_ms")]
+    public int? RemoteEmbeddingTimeoutMs { get; set; }
+
+    /// <summary>
+    /// The number of times to retry an API call to a remote embedding service on failure.
+    /// </summary>
+    [JsonPropertyName("remote_embedding_num_tries")]
+    public int? RemoteEmbeddingNumTries { get; set; }
+
     [Obsolete("Use multi-arity constructor instead.")]
     public SearchParameters()
     {


### PR DESCRIPTION
Closes #157 

- Support [Auto Embedding](https://typesense.org/docs/0.25.0/api/vector-search.html#option-b-auto-embedding-generation-within-typesense) and [Semantic Search](https://typesense.org/docs/0.25.0/api/vector-search.html#semantic-search)
- Updated typesense docker image version to `0.25.1.rc2` for integration testing
  - v0.25.1 has not yet released
  - v0.25.0 suffers from upstream bug (https://github.com/typesense/typesense/issues/1166)
