### PR TITLE
Client Extension: Extending Client to implement Disk Compaction Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,13 @@ Asynchronously initiates a snapshot operation on the Typesense server.
 ```c#
 var snapshotResponse = await typesenseClient.CreateSnapshot("/my_snapshot_path");
 ```
+## Disk Compaction
+
+Asynchronously initiates the running of a compaction of the underlying RocksDB database.
+
+```c#
+var diskCompactionResponse = await typesenseClient.CompactDisk();
+```
 
 ### Typesense API Errors
 

--- a/examples/Example/Program.cs
+++ b/examples/Example/Program.cs
@@ -133,6 +133,9 @@ sealed class Program
         
         // Example create collection snapshot
         await ExampleCreateSnapshot(typesenseClient);
+        
+        // Example disk compaction
+        await ExampleCompactDisk(typesenseClient);
     }
 
     private static async Task ExampleCreateCollection(ITypesenseClient typesenseClient)
@@ -490,5 +493,11 @@ sealed class Program
     {
         var snapshotResponse = await typesenseClient.CreateSnapshot("/my_snapshot_path");
         Console.WriteLine($"Snapshot: {JsonSerializer.Serialize(snapshotResponse)}");
+    }
+    
+    private static async Task ExampleCompactDisk(ITypesenseClient typesenseClient)
+    {
+        var compactDiskResponse = await typesenseClient.CompactDisk();
+        Console.WriteLine($"Compact disk: {JsonSerializer.Serialize(compactDiskResponse)}");
     }
 }

--- a/src/Typesense/CompactDiskResponse.cs
+++ b/src/Typesense/CompactDiskResponse.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Typesense;
+
+public record CompactDiskResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; init; }
+
+    [JsonConstructor]
+    public CompactDiskResponse(bool success)
+    {
+        Success = success;
+    }
+}

--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -704,4 +704,18 @@ public interface ITypesenseClient
      /// <exception cref="TypesenseApiNotFoundException"></exception>
      /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
      Task<SnapshotResponse> CreateSnapshot(string snapshotPath, CancellationToken ctk = default);
+     
+     /// <summary>
+     /// Asynchronously initiates the running of a compaction of the underlying RocksDB database.
+     /// Note: While the database will not block during this operation, we recommend running it during off-peak hours.
+     /// </summary>
+     /// <param name="ctk">The optional cancellation token.</param>
+     /// <returns>
+     /// A task that represents the asynchronous operation. The task result contains the outcome of the successful compaction.
+     /// </returns>
+     /// <exception cref="TypesenseApiException"></exception>
+     /// <exception cref="TypesenseApiBadRequestException"></exception>
+     /// <exception cref="TypesenseApiNotFoundException"></exception>
+     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
+     Task<CompactDiskResponse> CompactDisk(CancellationToken ctk = default);
 }

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -578,7 +578,6 @@ public class TypesenseClient : ITypesenseClient
     public async Task<CompactDiskResponse> CompactDisk(CancellationToken ctk = default)
     {
         var response = await Post("/operations/db/compact", ctk).ConfigureAwait(false);
-        
         return HandleEmptyStringJsonSerialize<CompactDiskResponse>(response, _jsonNameCaseInsentiveTrue);
     }
 

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -575,6 +575,13 @@ public class TypesenseClient : ITypesenseClient
         return HandleEmptyStringJsonSerialize<SnapshotResponse>(response, _jsonNameCaseInsentiveTrue);
     }
 
+    public async Task<CompactDiskResponse> CompactDisk(CancellationToken ctk = default)
+    {
+        var response = await Post("/operations/db/compact", ctk).ConfigureAwait(false);
+        
+        return HandleEmptyStringJsonSerialize<CompactDiskResponse>(response, _jsonNameCaseInsentiveTrue);
+    }
+
     private static string CreateUrlParameters<T>(T queryParameters)
         where T : notnull
     {

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -1850,6 +1850,18 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             response.Success.Should().BeTrue();
         }
     }
+    
+    [Fact, TestPriority(36)]
+    public async Task Can_Compact_Disk()
+    {
+        var response = await _client.CompactDisk();
+
+        using (var scope = new AssertionScope())
+        {
+            response.Success.Should().BeTrue();
+        }
+    }
+
 
     private async Task CreateCompanyCollection()
     {

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -1852,7 +1852,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
     }
     
     [Fact, TestPriority(36)]
-    public async Task Can_Compact_Disk()
+    public async Task Can_compact_disk()
     {
         var response = await _client.CompactDisk();
 
@@ -1861,8 +1861,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             response.Success.Should().BeTrue();
         }
     }
-
-
+    
     private async Task CreateCompanyCollection()
     {
         var schema = new Schema(

--- a/typesense-dotnet.sln.DotSettings.user
+++ b/typesense-dotnet.sln.DotSettings.user
@@ -1,6 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=a1723a18_002D7dd9_002D44d9_002Da9b1_002D78f1143771dc/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Can_Compact_Disk" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;xUnit::0E36B35F-11C7-4093-B2EE-AB1424885268::net6.0::Typesense.Tests.TypesenseClientTests.Can_Compact_Disk&lt;/TestId&gt;&#xD;
-  &lt;/TestAncestor&gt;&#xD;
-&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/typesense-dotnet.sln.DotSettings.user
+++ b/typesense-dotnet.sln.DotSettings.user
@@ -1,0 +1,6 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=a1723a18_002D7dd9_002D44d9_002Da9b1_002D78f1143771dc/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Can_Compact_Disk" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;xUnit::0E36B35F-11C7-4093-B2EE-AB1424885268::net6.0::Typesense.Tests.TypesenseClientTests.Can_Compact_Disk&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
Extending Client to implement Disk Compaction Functionality

As per docs.
https://typesense.org/docs/0.25.1/api/cluster-operations.html#compacting-the-on-disk-database

Note added on summary echoing typesense recommendations - While the database will not block during this operation, we recommend running it during off-peak hours.