### PR TITLE
Add SymbolsToIndex to synonyms

### DIFF
--- a/src/Typesense/SynonymSchema.cs
+++ b/src/Typesense/SynonymSchema.cs
@@ -11,6 +11,9 @@ public record SynonymSchema
     [JsonPropertyName("root")]
     public string? Root { get; init; }
 
+    [JsonPropertyName("symbols_to_index")]
+    public IEnumerable<string>? SymbolsToIndex { get; init; }
+
     public SynonymSchema(IEnumerable<string> synonyms)
     {
         Synonyms = synonyms;

--- a/src/Typesense/SynonymSchemaResponse.cs
+++ b/src/Typesense/SynonymSchemaResponse.cs
@@ -14,11 +14,18 @@ public record SynonymSchemaResponse
     [JsonPropertyName("root")]
     public string Root { get; init; }
 
+    [JsonPropertyName("symbols_to_index")]
+    public IReadOnlyCollection<string> SymbolsToIndex { get; init; }
+
     [JsonConstructor]
-    public SynonymSchemaResponse(string id, IReadOnlyCollection<string> synonyms, string root)
+    public SynonymSchemaResponse(string id,
+        IReadOnlyCollection<string> synonyms,
+        string root,
+        IReadOnlyCollection<string> symbolsToIndex)
     {
         Id = id;
         Synonyms = synonyms;
         Root = root;
+        SymbolsToIndex = symbolsToIndex;
     }
 }

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -1488,9 +1488,15 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         var expected = new SynonymSchemaResponse(
             "apple-synonyms",
             new List<string> { "appl", "aple", "apple" },
-            "apple");
+            "apple",
+            new List<string> { "+" });
 
-        var schema = new SynonymSchema(new List<string> { "appl", "aple", "apple" }) { Root = "apple" };
+        var schema = new SynonymSchema(new List<string> { "appl", "aple", "apple" })
+        {
+            Root = "apple",
+            SymbolsToIndex = new List<string> { "+" }
+        };
+
         var response = await _client.UpsertSynonym("companies", "apple-synonyms", schema);
 
         response.Should().BeEquivalentTo(expected);
@@ -1502,7 +1508,8 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         var expected = new SynonymSchemaResponse(
             "apple-synonyms",
             new List<string> { "appl", "aple", "apple" },
-            "apple");
+            "apple",
+            new List<string> { "+" });
 
         var response = await _client.RetrieveSynonym("companies", "apple-synonyms");
 
@@ -1518,7 +1525,8 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new SynonymSchemaResponse(
                     "apple-synonyms",
                     new List<string> { "appl", "aple", "apple" },
-                    "apple")
+                    "apple",
+                    new List<string> { "+" })
             });
 
         var response = await _client.ListSynonyms("companies");


### PR DESCRIPTION
We need the `symbols_to_index` (can be found [here](https://typesense.org/docs/0.25.1/api/synonyms.html#create-or-update-a-synonym), last argument) on synonyms for our use case.

I added them to the `SynonymSchema` and `SynonymSchemaResponse` according to `SymbolsToIndex` from `Schema` and `CollectionResponse` and extended the existing tests to include the parameter. I'm not quite sure if that's correct tho.

I don't know why my IDE added the two using statements but when I remove them stuff won't build. I can remove them when they are not wanted.