### PR TITLE
can now specify the vector field name

### DIFF
--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -1628,6 +1628,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 // vec:([0.96826, 0.94, 0.39557, 0.306488], k:100)
                 VectorQuery = new(
                     vector: new float[] { 0.96826F, 0.94F, 0.39557F, 0.306488F },
+                    vectorFieldName: "vec",
                     k: 100)
             };
 


### PR DESCRIPTION
Fixes #184.

## This is a breaking change.

When this was first implemented in #145 and #146 it was not though of that users might specify other names for the vector field in the document.

If you have used it before, it is easy to change. It is now **always** required to specify the `vectorFieldName`.

### New way

``` c#
VectorQuery = new(
    vector: new float[] { 0.96826F, 0.94F, 0.39557F, 0.306488F },
    vectorFieldName: "vec",
    k: 100)
```

### Old way

```C#
VectorQuery = new(
    vector: new float[] { 0.96826F, 0.94F, 0.39557F, 0.306488F },
    k: 100)
```