### PR TITLE
Feature: Adding document update by filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ var provider = new ServiceCollection()
 ```
 
 After that you can get it from the `provider` instance or dependency inject it.
-
 ```c#
 var typesenseClient = provider.GetService<ITypesenseClient>();
 ```
@@ -32,7 +31,7 @@ var typesenseClient = provider.GetService<ITypesenseClient>();
 
 When you create the collection, you can specify each field with `name`, `type` and if it should be a `facet`, an `optional` or an `indexed` field.
 
-```c#
+``` c#
 var schema = new Schema(
     "Addresses",
     new List<Field>
@@ -131,6 +130,7 @@ var query = new MultiSearchParameters("companies", "Stark", "company_name");
 var response = await _client.MultiSearch<Company>(queryOne);
 ```
 
+
 Example of using a two queries in multi-search.
 
 ```c#
@@ -210,16 +210,16 @@ var updateDocumentResult = await typesenseClient.UpdateDocument<Address>("Addres
 var deleteResult = await typesenseClient.DeleteDocument<Address>("Addresses", "1");
 ```
 
-## Delete documents using filter
-
-```c#
-var deleteResult = await typesenseClient.DeleteDocuments("Addresses", "houseNumber:>=3", 100);
-```
-
 ## Update documents using filter
 
 ```c#
 var updateResult = await typesenseClient.UpdateDocuments("Addresses", "houseNumber:=2", { "accessAddress": "Smedgade 25C" }, 100);
+```
+
+## Delete documents using filter
+
+```c#
+var deleteResult = await typesenseClient.DeleteDocuments("Addresses", "houseNumber:>=3", 100);
 ```
 
 ## Drop a collection on name
@@ -247,6 +247,7 @@ var addresses = await typesenseClient.ExportDocuments<Address>("Addresses");
 ```
 
 ## Api keys
+
 
 ### Create key
 
@@ -291,6 +292,7 @@ var scopedSearchKey = typesenseClient.GenerateScopedSearchKey("MainOrParentAPIKe
 While Typesense makes it really easy and intuitive to deliver great search results, sometimes you might want to promote certain documents over others. Or, you might want to exclude certain documents from a query's result set.
 
 Using overrides, you can include or exclude specific documents for a given query.
+
 
 ### Upsert
 
@@ -404,7 +406,6 @@ Asynchronously initiates a snapshot operation on the Typesense server.
 ```c#
 var snapshotResponse = await typesenseClient.CreateSnapshot("/my_snapshot_path");
 ```
-
 ## Disk Compaction
 
 Asynchronously initiates the running of a compaction of the underlying RocksDB database.
@@ -418,7 +419,7 @@ var diskCompactionResponse = await typesenseClient.CompactDisk();
 Typesense API exceptions in the [Typesense-api-errors](https://typesense.org/docs/0.23.0/api/api-errors.html) spec.
 
 | Type                                       | Description                                                                |
-| :----------------------------------------- | :------------------------------------------------------------------------- |
+|:-------------------------------------------|:---------------------------------------------------------------------------|
 | `TypesenseApiException`                    | Base exception type for Typesense api exceptions.                          |
 | `TypesenseApiBadRequestException`          | Bad Request - The request could not be understood due to malformed syntax. |
 | `TypesenseApiUnauthorizedException`        | Unauthorized - Your API key is wrong.                                      |
@@ -436,7 +437,6 @@ dotnet test
 ```
 
 ### Running only unit tests
-
 ```sh
 dotnet test --filter Category=Unit
 ```
@@ -448,6 +448,7 @@ dotnet test --filter Category=Integration
 ```
 
 To run integration tests, you can execute Typesense in a docker container by using the command below. The process utilizes the `/tmp/data` folder however, if you prefer to place it in a different directory, you can modify the path accordingly.
+
 
 ```sh
 docker run -p 8108:8108 -v /tmp/data:/data typesense/typesense:0.25.1 --data-dir /data --api-key=key

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ var deleteResult = await typesenseClient.DeleteDocument<Address>("Addresses", "1
 ## Update documents using filter
 
 ```c#
-var updateResult = await typesenseClient.UpdateDocuments("Addresses", "houseNumber:=2", { "accessAddress": "Smedgade 25C" }, 100);
+var updateResult = await typesenseClient.UpdateDocuments("Addresses", "houseNumber:=2", { "accessAddress": "Smedgade 25C" });
 ```
 
 ## Delete documents using filter

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ var provider = new ServiceCollection()
 ```
 
 After that you can get it from the `provider` instance or dependency inject it.
+
 ```c#
 var typesenseClient = provider.GetService<ITypesenseClient>();
 ```
@@ -31,7 +32,7 @@ var typesenseClient = provider.GetService<ITypesenseClient>();
 
 When you create the collection, you can specify each field with `name`, `type` and if it should be a `facet`, an `optional` or an `indexed` field.
 
-``` c#
+```c#
 var schema = new Schema(
     "Addresses",
     new List<Field>
@@ -130,7 +131,6 @@ var query = new MultiSearchParameters("companies", "Stark", "company_name");
 var response = await _client.MultiSearch<Company>(queryOne);
 ```
 
-
 Example of using a two queries in multi-search.
 
 ```c#
@@ -216,6 +216,12 @@ var deleteResult = await typesenseClient.DeleteDocument<Address>("Addresses", "1
 var deleteResult = await typesenseClient.DeleteDocuments("Addresses", "houseNumber:>=3", 100);
 ```
 
+## Update documents using filter
+
+```c#
+var updateResult = await typesenseClient.UpdateDocuments("Addresses", "houseNumber:=2", { "accessAddress": "Smedgade 25C" }, 100);
+```
+
 ## Drop a collection on name
 
 ```c#
@@ -241,7 +247,6 @@ var addresses = await typesenseClient.ExportDocuments<Address>("Addresses");
 ```
 
 ## Api keys
-
 
 ### Create key
 
@@ -286,7 +291,6 @@ var scopedSearchKey = typesenseClient.GenerateScopedSearchKey("MainOrParentAPIKe
 While Typesense makes it really easy and intuitive to deliver great search results, sometimes you might want to promote certain documents over others. Or, you might want to exclude certain documents from a query's result set.
 
 Using overrides, you can include or exclude specific documents for a given query.
-
 
 ### Upsert
 
@@ -400,6 +404,7 @@ Asynchronously initiates a snapshot operation on the Typesense server.
 ```c#
 var snapshotResponse = await typesenseClient.CreateSnapshot("/my_snapshot_path");
 ```
+
 ## Disk Compaction
 
 Asynchronously initiates the running of a compaction of the underlying RocksDB database.
@@ -413,7 +418,7 @@ var diskCompactionResponse = await typesenseClient.CompactDisk();
 Typesense API exceptions in the [Typesense-api-errors](https://typesense.org/docs/0.23.0/api/api-errors.html) spec.
 
 | Type                                       | Description                                                                |
-|:-------------------------------------------|:---------------------------------------------------------------------------|
+| :----------------------------------------- | :------------------------------------------------------------------------- |
 | `TypesenseApiException`                    | Base exception type for Typesense api exceptions.                          |
 | `TypesenseApiBadRequestException`          | Bad Request - The request could not be understood due to malformed syntax. |
 | `TypesenseApiUnauthorizedException`        | Unauthorized - Your API key is wrong.                                      |
@@ -431,6 +436,7 @@ dotnet test
 ```
 
 ### Running only unit tests
+
 ```sh
 dotnet test --filter Category=Unit
 ```
@@ -442,7 +448,6 @@ dotnet test --filter Category=Integration
 ```
 
 To run integration tests, you can execute Typesense in a docker container by using the command below. The process utilizes the `/tmp/data` folder however, if you prefer to place it in a different directory, you can modify the path accordingly.
-
 
 ```sh
 docker run -p 8108:8108 -v /tmp/data:/data typesense/typesense:0.25.1 --data-dir /data --api-key=key

--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -319,14 +319,13 @@ public interface ITypesenseClient
     /// <param name="collection">The collection name.</param>
     /// <param name="document">A documents of type T to update the filtered collection list with.</param>
     /// <param name="filter">The filter that is used to selected which documents that should be updated.</param>
-    /// <param name="batchSize">The number of documents that should updated at a time.</param>
     /// <returns>A response containing a count of the updated documents.</returns>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="TypesenseApiException"></exception>
     /// <exception cref="TypesenseApiBadRequestException"></exception>
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
-    Task<FilterUpdateResponse> UpdateDocuments<T>(string collection, T document, string filter, int batchSize = 40);
+    Task<FilterUpdateResponse> UpdateDocuments<T>(string collection, T document, string filter);
     
     /// <summary>
     /// Batch import documents.

--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -314,6 +314,21 @@ public interface ITypesenseClient
     Task<UpdateCollectionResponse> UpdateCollection(string name, UpdateSchema updateSchema);
 
     /// <summary>
+    /// Updates documents in a collection using the supplied filter.
+    /// </summary>
+    /// <param name="collection">The collection name.</param>
+    /// <param name="document">A documents of type T to update the filtered collection list with.</param>
+    /// <param name="filter">The filter that is used to selected which documents that should be updated.</param>
+    /// <param name="batchSize">The number of documents that should updated at a time.</param>
+    /// <returns>A response containing a count of the updated documents.</returns>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="TypesenseApiException"></exception>
+    /// <exception cref="TypesenseApiBadRequestException"></exception>
+    /// <exception cref="TypesenseApiNotFoundException"></exception>
+    /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
+    Task<FilterUpdateResponse> UpdateDocuments<T>(string collection, T document, string filter, int batchSize = 40);
+    
+    /// <summary>
     /// Batch import documents.
     /// </summary>
     /// <param name="collection">The collection name.</param>

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -278,7 +278,7 @@ public class TypesenseClient : ITypesenseClient
             _jsonNameCaseInsentiveTrue);
     }
 
-    public async Task<FilterUpdateResponse> UpdateDocuments<T>(string collection, T document, string filter, int batchSize = 40)
+    public async Task<FilterUpdateResponse> UpdateDocuments<T>(string collection, T document, string filter)
     {
         if (string.IsNullOrWhiteSpace(collection))
             throw new ArgumentException("cannot be null empty or whitespace", nameof(collection));
@@ -286,12 +286,10 @@ public class TypesenseClient : ITypesenseClient
             throw new ArgumentNullException(nameof(document), "cannot be null");
         if (string.IsNullOrWhiteSpace(filter))
             throw new ArgumentException("cannot be null empty or whitespace", nameof(filter));
-        if (batchSize < 0)
-            throw new ArgumentException("has to be greater than 0", nameof(batchSize));
     
         var json = JsonSerializer.Serialize(document, _jsonOptionsCamelCaseIgnoreWritingNull);
     
-        var response = await Patch($"collections/{collection}/documents?filter_by={Uri.EscapeDataString(filter)}&batch_size={batchSize}&action=update", json).ConfigureAwait(false);
+        var response = await Patch($"collections/{collection}/documents?filter_by={Uri.EscapeDataString(filter)}&action=update", json).ConfigureAwait(false);
 
         return HandleEmptyStringJsonSerialize<FilterUpdateResponse>(response, _jsonNameCaseInsentiveTrue);
     }

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -32,7 +32,7 @@ public class TypesenseClient : ITypesenseClient
 
         var node = config.Value.Nodes.First();
         httpClient.BaseAddress = new Uri($"{node.Protocol}://{node.Host}:{node.Port}");
-        httpClient.DefaultRequestHeaders.Add("X-TYPESENSE-API-KEY", "Hu52dwsas2AdxdE");
+        httpClient.DefaultRequestHeaders.Add("X-TYPESENSE-API-KEY", config.Value.ApiKey);
         _httpClient = httpClient;
     }
 

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -32,7 +32,7 @@ public class TypesenseClient : ITypesenseClient
 
         var node = config.Value.Nodes.First();
         httpClient.BaseAddress = new Uri($"{node.Protocol}://{node.Host}:{node.Port}");
-        httpClient.DefaultRequestHeaders.Add("X-TYPESENSE-API-KEY", config.Value.ApiKey);
+        httpClient.DefaultRequestHeaders.Add("X-TYPESENSE-API-KEY", "Hu52dwsas2AdxdE");
         _httpClient = httpClient;
     }
 
@@ -276,6 +276,24 @@ public class TypesenseClient : ITypesenseClient
         return HandleEmptyStringJsonSerialize<UpdateCollectionResponse>(
             response,
             _jsonNameCaseInsentiveTrue);
+    }
+
+    public async Task<FilterUpdateResponse> UpdateDocuments<T>(string collection, T document, string filter, int batchSize = 40)
+    {
+        if (string.IsNullOrWhiteSpace(collection))
+            throw new ArgumentException("cannot be null empty or whitespace", nameof(collection));
+        if (document == null)
+            throw new ArgumentNullException(nameof(document), "cannot be null");
+        if (string.IsNullOrWhiteSpace(filter))
+            throw new ArgumentException("cannot be null empty or whitespace", nameof(filter));
+        if (batchSize < 0)
+            throw new ArgumentException("has to be greater than 0", nameof(batchSize));
+    
+        var json = JsonSerializer.Serialize(document, _jsonOptionsCamelCaseIgnoreWritingNull);
+    
+        var response = await Patch($"collections/{collection}/documents?filter_by={Uri.EscapeDataString(filter)}&batch_size={batchSize}&action=update", json).ConfigureAwait(false);
+
+        return HandleEmptyStringJsonSerialize<FilterUpdateResponse>(response, _jsonNameCaseInsentiveTrue);
     }
 
     public async Task<List<ImportResponse>> ImportDocuments<T>(

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -119,7 +119,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
 
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(0)]
     public async Task Create_schema_symbols_to_index_and_token_seperator()
     {
@@ -160,7 +160,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<string> { "-" },
             new List<string> { "+" },
             true);
-    
+
         var schema = new Schema(
             "companies_with_symbols_and_token",
             new List<Field>
@@ -175,15 +175,15 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             SymbolsToIndex = new List<string> { "+" },
             EnableNestedFields = true,
         };
-    
+
         var response = await _client.CreateCollection(schema);
-    
+
         response.Should().BeEquivalentTo(expected);
-    
+
         // Cleanup
         await _client.DeleteCollection(schema.Name);
     }
-    
+
     // We test wildcard field individually,
     // because it is a bit different than other types of fields.
     [Fact, TestPriority(0)]
@@ -208,29 +208,29 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<string>(),
             new List<string>(),
             false);
-    
+
         var schema = new Schema(
             "wildcard-collection",
             new List<Field>
             {
                 new Field(".*", FieldType.String, false),
             });
-    
+
         var response = await _client.CreateCollection(schema);
-    
+
         response.Should().BeEquivalentTo(expected);
-    
+
         // Cleanup
         await _client.DeleteCollection("wildcard-collection");
     }
-    
+
     // We test wildcard field individually,
     // because it is a bit different than other types of fields.
     [Fact, TestPriority(0)]
     public async Task Create_schema_with_locale_on_field()
     {
         const string collectionName = "collection-with-locale";
-    
+
         var expected = new CollectionResponse(
             collectionName,
             0,
@@ -251,7 +251,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<string>(),
             new List<string>(),
             false);
-    
+
         var schema = new Schema(
             collectionName,
             new List<Field>
@@ -262,15 +262,15 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     optional: true,
                     locale: "zh"),
             });
-    
+
         var response = await _client.CreateCollection(schema);
-    
+
         response.Should().BeEquivalentTo(expected);
-    
+
         // Cleanup
         await _client.DeleteCollection(collectionName);
     }
-    
+
     [Fact, TestPriority(1)]
     public async Task Retrieve_collection()
     {
@@ -311,12 +311,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<string>(),
             new List<string>(),
             true);
-    
+
         var response = await _client.RetrieveCollection("companies");
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(2)]
     public async Task Retrieve_collections()
     {
@@ -360,11 +360,11 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new List<string>(),
                 true)
         };
-    
+
         var response = await _client.RetrieveCollections();
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(2)]
     public async Task Update_collection()
     {
@@ -375,15 +375,15 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new UpdateSchemaField("non_profit", FieldType.Bool)
             }
         );
-    
+
         var result = await _client.UpdateCollection("companies", updateSchema);
-    
+
         result.Fields.Should().Satisfy(
             e => e.Name == "company_name" && e.Drop == true,
             e => e.Name == "non_profit" && e.Type == FieldType.Bool
         );
     }
-    
+
     [Fact, TestPriority(3)]
     public async Task Delete_collection()
     {
@@ -424,18 +424,18 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<string>(),
             new List<string>(),
             true);
-    
+
         var result = await _client.DeleteCollection("companies");
-    
+
         result.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(4)]
     public async Task Index_document()
     {
         // We create collection for test cases.
         await CreateCompanyCollection();
-    
+
         var company = new Company
         {
             Id = "124",
@@ -447,12 +447,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var response = await _client.CreateDocument<Company>("companies", company);
-    
+
         response.Should().BeEquivalentTo(company);
     }
-    
+
     [Fact, TestPriority(5)]
     public async Task Upsert_document_existing_document()
     {
@@ -467,12 +467,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var response = await _client.UpsertDocument<Company>("companies", company);
-    
+
         response.Should().BeEquivalentTo(company);
     }
-    
+
     [Fact, TestPriority(6)]
     public async Task Upsert_document_new_document()
     {
@@ -487,12 +487,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "SWE"
             },
         };
-    
+
         var response = await _client.UpsertDocument<Company>("companies", company);
-    
+
         response.Should().BeEquivalentTo(company);
     }
-    
+
     [Fact, TestPriority(7)]
     public async Task Import_documents_create()
     {
@@ -501,7 +501,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new ImportResponse(true),
             new ImportResponse(true),
         };
-    
+
         var companies = new List<Company>
         {
             new Company
@@ -527,13 +527,13 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 },
             }
         };
-    
+
         var response = await _client.ImportDocuments<Company>(
             "companies", companies, 40, ImportType.Create);
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(7)]
     public async Task Import_documents_update()
     {
@@ -542,7 +542,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new ImportResponse(true),
             new ImportResponse(true),
         };
-    
+
         var companies = new List<Company>
         {
             new Company
@@ -568,12 +568,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 },
             }
         };
-    
+
         var response = await _client.ImportDocuments<Company>("companies", companies, 40, ImportType.Update);
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(7)]
     public async Task Import_documents_upsert()
     {
@@ -582,7 +582,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new ImportResponse(true),
             new ImportResponse(true),
         };
-    
+
         var companies = new List<Company>
         {
             new Company
@@ -608,13 +608,13 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 },
             }
         };
-    
+
         var response = await _client.ImportDocuments<Company>(
             "companies", companies, 40, ImportType.Upsert);
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(7)]
     public async Task Import_documents_emplace()
     {
@@ -623,7 +623,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new ImportResponse(true),
             new ImportResponse(true),
         };
-    
+
         var companies = new List<Company>
         {
             new Company
@@ -649,13 +649,13 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 },
             }
         };
-    
+
         var response = await _client.ImportDocuments<Company>(
             "companies", companies, 40, ImportType.Emplace);
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(8)]
     public async Task Export_documents()
     {
@@ -706,12 +706,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 },
             }
         };
-    
+
         var response = await _client.ExportDocuments<Company>("companies");
-    
+
         response.OrderBy(x => x.Id).Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(8)]
     public async Task Export_documents_filter_by_query()
     {
@@ -729,12 +729,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 },
             }
         };
-    
+
         var response = await _client.ExportDocuments<Company>("companies", new ExportParameters { FilterBy = "id: [124]" });
-    
+
         response.OrderBy(x => x.Id).Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(8)]
     public async Task Export_documents_include_fields()
     {
@@ -761,12 +761,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 CompanyName = "Awesome A/S"
             }
         };
-    
+
         var response = await _client.ExportDocuments<Company>("companies", new ExportParameters { IncludeFields = "id,company_name" });
-    
+
         response.OrderBy(x => x.Id).Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(8)]
     public async Task Export_documents_exclude_fields()
     {
@@ -813,12 +813,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 },
             }
         };
-    
+
         var response = await _client.ExportDocuments<Company>("companies", new ExportParameters { ExcludeFields = "num_employees" });
-    
+
         response.OrderBy(x => x.Id).Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(9)]
     public async Task Retrieve_document()
     {
@@ -833,12 +833,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var response = await _client.RetrieveDocument<Company>("companies", "124");
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(10)]
     public async Task Update_document()
     {
@@ -853,12 +853,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var response = await _client.UpdateDocument("companies", "124", company);
-    
+
         response.Should().BeEquivalentTo(response);
     }
-    
+
     [Fact, TestPriority(11)]
     public async Task Search_query_by_just_text()
     {
@@ -873,18 +873,18 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var query = new SearchParameters("Stark", "company_name");
-    
+
         var response = await _client.Search<Company>("companies", query);
-    
+
         using (var scope = new AssertionScope())
         {
             response.Found.Should().Be(1);
             response.Hits.First().Document.Should().BeEquivalentTo(expected);
         }
     }
-    
+
     [Fact, TestPriority(11)]
     public async Task Search_query_by_just_text_with_full_search_field()
     {
@@ -899,14 +899,14 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var query = new SearchParameters("Stark", "company_name")
         {
             HighlightFullFields = "company_name"
         };
-    
+
         var response = await _client.Search<Company>("companies", query);
-    
+
         using (var scope = new AssertionScope())
         {
             response.Found.Should().Be(1);
@@ -916,7 +916,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             response.Hits.First().Highlights.First().Value.Should().NotBeNullOrEmpty();
         }
     }
-    
+
     [Fact, TestPriority(11)]
     public async Task Search_query_by_just_text_with_split_join_tokens_set()
     {
@@ -931,21 +931,21 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var query = new SearchParameters("Stark", "company_name")
         {
             SplitJoinTokens = SplitJoinTokenOption.Fallback
         };
-    
+
         var response = await _client.Search<Company>("companies", query);
-    
+
         using (var scope = new AssertionScope())
         {
             response.Found.Should().Be(1);
             response.Hits.First().Document.Should().BeEquivalentTo(expected);
         }
     }
-    
+
     [Fact, TestPriority(11)]
     public async Task Search_query_by_two_fields()
     {
@@ -960,17 +960,17 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var query = new SearchParameters("Stark", "company_name,location.country");
         var response = await _client.Search<Company>("companies", query);
-    
+
         using (var scope = new AssertionScope())
         {
             response.Found.Should().Be(1);
             response.Hits.First().Document.Should().BeEquivalentTo(expected);
         }
     }
-    
+
     [Fact, TestPriority(11)]
     public async Task Search_facet_by_country()
     {
@@ -980,21 +980,21 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new FacetCountHit("SWE", 1, "SWE"),
             new FacetCountHit("USA", 1, "USA"),
         }, new FacetStats(0, 0, 0, 0, 3));
-    
+
         var query = new SearchParameters("", "company_name")
         {
             FacetBy = "location.country"
         };
-    
+
         var response = await _client.Search<Company>("companies", query);
-    
+
         using (var scope = new AssertionScope())
         {
             response.FacetCounts.Should().HaveCount(1);
             response.FacetCounts.First().Should().BeEquivalentTo(expected);
         }
     }
-    
+
     [Fact, TestPriority(11)]
     public async Task Search_facet_by_num_employees()
     {
@@ -1005,21 +1005,21 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new FacetCountHit( "1232", 1, "1232"),
             new FacetCountHit( "6000", 1, "6000"),
         }, new FacetStats(1943.25F, 6000F, 10F, 7773F, 4));
-    
+
         var query = new SearchParameters("", "company_name")
         {
             FacetBy = "num_employees"
         };
-    
+
         var response = await _client.Search<Company>("companies", query);
-    
+
         using (var scope = new AssertionScope())
         {
             response.FacetCounts.Should().HaveCount(1);
             response.FacetCounts.First().Should().BeEquivalentTo(expected);
         }
     }
-    
+
     [Fact, TestPriority(11)]
     public async Task Search_facet_by_country_with_query()
     {
@@ -1027,27 +1027,27 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         {
             new FacetCountHit("USA", 1, "USA"),
         }, new FacetStats(0, 0, 0, 0, 1));
-    
+
         var query = new SearchParameters("Stark", "company_name")
         {
             FacetBy = "location.country"
         };
-    
+
         var response = await _client.Search<Company>("companies", query);
-    
+
         using (var scope = new AssertionScope())
         {
             response.FacetCounts.Should().HaveCount(1);
             response.FacetCounts.First().Should().BeEquivalentTo(expected);
         }
     }
-    
+
     [Fact, TestPriority(11)]
     public async Task Search_grouped_by_country()
     {
         var query = new GroupedSearchParameters("Stark", "company_name", "location.country");
         var response = await _client.SearchGrouped<Company>("companies", query);
-    
+
         using (var scope = new AssertionScope())
         {
             response.Found.Should().Be(1);
@@ -1057,7 +1057,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             firstHit.GroupKey.Should().BeEquivalentTo("USA");
         }
     }
-    
+
     [Fact, TestPriority(11)]
     public async Task Multi_search_query_single_type_multiple_multi_search_parameters()
     {
@@ -1072,7 +1072,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var responses = await _client.MultiSearch<Company>(
             new List<MultiSearchParameters>
             {
@@ -1086,7 +1086,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new MultiSearchParameters("companies", "Stark", "company_name"),
                 new MultiSearchParameters("companies", "Stark", "company_name")
             });
-    
+
         using (var scope = new AssertionScope())
         {
             responses.Count().Should().Be(6);
@@ -1097,7 +1097,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             }
         }
     }
-    
+
     [Fact, TestPriority(11)]
     public async Task Multi_search_query_single_type_multiple_multi_search_parameters_one_failed()
     {
@@ -1112,7 +1112,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var responses = await _client.MultiSearch<Company>(
             new List<MultiSearchParameters>
             {
@@ -1122,17 +1122,17 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new MultiSearchParameters("companies", "Stark", "company_name"),
                 new MultiSearchParameters("this_collection_does_not_exist", "Stark", "company_name"),
             });
-    
+
         using (var scope = new AssertionScope())
         {
             responses.Count().Should().Be(2);
-    
+
             // Validate that first has no errors.
             responses[0].Found.Should().Be(1);
             responses[0].Hits.First().Document.Should().BeEquivalentTo(expected);
             responses[0].ErrorMessage.Should().BeNull();
             responses[0].ErrorCode.Should().BeNull();
-    
+
             // Validate that second has errors.
             responses[1].Found.Should().BeNull();
             responses[1].Hits.Should().BeNull();
@@ -1140,7 +1140,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             responses[1].ErrorCode.Should().Be(404);
         }
     }
-    
+
     [Fact, TestPriority(11)]
     public async Task Multi_search_query_single()
     {
@@ -1155,17 +1155,17 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var query = new MultiSearchParameters("companies", "Stark", "company_name");
         var response = await _client.MultiSearch<Company>(query);
-    
+
         using (var scope = new AssertionScope())
         {
             response.Found.Should().Be(1);
             response.Hits.First().Document.Should().BeEquivalentTo(expected);
         }
     }
-    
+
     [Fact, TestPriority(11)]
     public async Task Multi_search_query_two()
     {
@@ -1180,23 +1180,23 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var query = new MultiSearchParameters("companies", "Stark", "company_name");
-    
+
         // We just use the same for queries for simplicity.
         // We mainly care about multiple queries being returned with the correct types of <T>.
         var (r1, r2) = await _client.MultiSearch<Company, Company>(query, query);
-    
+
         using (var scope = new AssertionScope())
         {
             r1.Found.Should().Be(1);
             r1.Hits.First().Document.Should().BeEquivalentTo(expected);
-    
+
             r2.Found.Should().Be(1);
             r2.Hits.First().Document.Should().BeEquivalentTo(expected);
         }
     }
-    
+
     [Fact, TestPriority(11)]
     public async Task Multi_search_query_three()
     {
@@ -1211,26 +1211,26 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var query = new MultiSearchParameters("companies", "Stark", "company_name");
-    
+
         // We just use the same for queries for simplicity.
         // We mainly care about multiple queries being returned with the correct types of <T>.
         var (r1, r2, r3) = await _client.MultiSearch<Company, Company, Company>(query, query, query);
-    
+
         using (var scope = new AssertionScope())
         {
             r1.Found.Should().Be(1);
             r1.Hits.First().Document.Should().BeEquivalentTo(expected);
-    
+
             r2.Found.Should().Be(1);
             r2.Hits.First().Document.Should().BeEquivalentTo(expected);
-    
+
             r3.Found.Should().Be(1);
             r3.Hits.First().Document.Should().BeEquivalentTo(expected);
         }
     }
-    
+
     [Fact, TestPriority(11)]
     public async Task Multi_search_query_four()
     {
@@ -1245,29 +1245,29 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var query = new MultiSearchParameters("companies", "Stark", "company_name");
-    
+
         // We just use the same for queries for simplicity.
         // We mainly care about multiple queries being returned with the correct types of <T>.
         var (r1, r2, r3, r4) = await _client.MultiSearch<Company, Company, Company, Company>(query, query, query, query);
-    
+
         using (var scope = new AssertionScope())
         {
             r1.Found.Should().Be(1);
             r1.Hits.First().Document.Should().BeEquivalentTo(expected);
-    
+
             r2.Found.Should().Be(1);
             r2.Hits.First().Document.Should().BeEquivalentTo(expected);
-    
+
             r3.Found.Should().Be(1);
             r3.Hits.First().Document.Should().BeEquivalentTo(expected);
-    
+
             r4.Found.Should().Be(1);
             r4.Hits.First().Document.Should().BeEquivalentTo(expected);
         }
     }
-    
+
     [Fact, TestPriority(12)]
     public async Task Delete_document_by_id()
     {
@@ -1282,21 +1282,21 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-    
+
         var response = await _client.DeleteDocument<Company>("companies", "124");
-    
+
         response.Should().BeEquivalentTo(response);
     }
-    
+
     [Fact, TestPriority(13)]
     public async Task Delete_document_by_query()
     {
         var expected = new FilterDeleteResponse(2);
         var response = await _client.DeleteDocuments("companies", "num_employees:>100");
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(14)]
     public async Task Create_api_key()
     {
@@ -1308,9 +1308,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             Value = "Example-api-1-key-value",
             ExpiresAt = 1661344547
         };
-    
+
         var response = await _client.CreateKey(expected);
-    
+
         using (var scope = new AssertionScope())
         {
             response.Description.Should().BeEquivalentTo(expected.Description);
@@ -1320,18 +1320,18 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             response.ExpiresAt.Should().Be(expected.ExpiresAt);
         }
     }
-    
+
     [Fact, TestPriority(15)]
     public async Task Retrieve_api_key()
     {
         var apiKeys = await _client.ListKeys();
         var apiKey = apiKeys.Keys.First();
-    
+
         var response = await _client.RetrieveKey(apiKey.Id);
-    
+
         response.Should().BeEquivalentTo(apiKey);
     }
-    
+
     [Fact, TestPriority(16)]
     public async Task List_keys()
     {
@@ -1343,9 +1343,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             Value = "Example-api-1-key-value",
             ExpiresAt = 1661344547
         };
-    
+
         var response = await _client.ListKeys();
-    
+
         response.Keys.Should()
             .HaveCount(1).And
             .SatisfyRespectively(
@@ -1358,7 +1358,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     first.ExpiresAt.Should().Be(expected.ExpiresAt);
                 });
     }
-    
+
     [Fact, TestPriority(17)]
     public async Task Delete_api_key()
     {
@@ -1368,12 +1368,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         {
             Id = apiKey.Id
         };
-    
+
         var response = await _client.DeleteKey(apiKey.Id);
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(18)]
     public async Task Upsert_search_override()
     {
@@ -1386,23 +1386,23 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     new Include("54", 2)
                 },
         };
-    
+
         var response = await _client.UpsertSearchOverride(
             "companies", "customize-apple", searchOverride);
     }
-    
+
     [Fact, TestPriority(19)]
     public async Task Retrive_search_override()
     {
         var searchOverrides = await _client.ListSearchOverrides("companies");
-    
+
         var expected = searchOverrides.SearchOverrides.First();
-    
+
         var response = await _client.RetrieveSearchOverride("companies", expected.Id);
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(20)]
     public async Task List_search_overrides()
     {
@@ -1415,9 +1415,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     new Include("54", 2)
                 },
         };
-    
+
         var response = await _client.ListSearchOverrides("companies");
-    
+
         response.SearchOverrides.Should()
             .HaveCount(1).And
             .SatisfyRespectively(
@@ -1428,29 +1428,29 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     first.Rule.Should().BeEquivalentTo(expected.Rule);
                 });
     }
-    
+
     [Fact, TestPriority(21)]
     public async Task Delete_search_override()
     {
         var expected = new DeleteSearchOverrideResponse("customize-apple");
-    
+
         var response = await _client.DeleteSearchOverride("companies", "customize-apple");
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(22)]
     [Trait("Category", "Integration")]
     public async Task Upsert_collection_alias()
     {
         var expected = new CollectionAliasResponse("companies", "my-companies-alias");
-    
+
         var response = await _client.UpsertCollectionAlias(
             "my-companies-alias", new CollectionAlias("companies"));
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(23)]
     public async Task List_collection_aliases()
     {
@@ -1458,32 +1458,32 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         {
             new CollectionAliasResponse("companies", "my-companies-alias")
         });
-    
+
         var response = await _client.ListCollectionAliases();
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(24)]
     public async Task Retrieve_collection_alias()
     {
         var expected = new CollectionAliasResponse("companies", "my-companies-alias");
-    
+
         var response = await _client.RetrieveCollectionAlias("my-companies-alias");
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(25)]
     public async Task Delete_collection_alias()
     {
         var expected = new CollectionAliasResponse("companies", "my-companies-alias");
-    
+
         var response = await _client.DeleteCollectionAlias("my-companies-alias");
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(26)]
     public async Task Upsert_synonym()
     {
@@ -1492,18 +1492,18 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<string> { "appl", "aple", "apple" },
             "apple",
             new List<string> { "+" });
-    
+
         var schema = new SynonymSchema(new List<string> { "appl", "aple", "apple" })
         {
             Root = "apple",
             SymbolsToIndex = new List<string> { "+" }
         };
-    
+
         var response = await _client.UpsertSynonym("companies", "apple-synonyms", schema);
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(27)]
     public async Task Retrieve_synonym()
     {
@@ -1512,12 +1512,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<string> { "appl", "aple", "apple" },
             "apple",
             new List<string> { "+" });
-    
+
         var response = await _client.RetrieveSynonym("companies", "apple-synonyms");
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(28)]
     public async Task List_synonyms()
     {
@@ -1530,26 +1530,26 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     "apple",
                     new List<string> { "+" })
             });
-    
+
         var response = await _client.ListSynonyms("companies");
-    
+
         response.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact, TestPriority(29)]
     public async Task Delete_synonym()
     {
         var expected = new DeleteSynonymResponse("apple-synonyms");
         var response = await _client.DeleteSynonym("companies", "apple-synonyms");
-    
+
         response.Should().Be(expected);
     }
-    
+
     [Fact, TestPriority(30)]
     public async Task Can_retrieve_metrics()
     {
         var response = await _client.RetrieveMetrics();
-    
+
         using (var scope = new AssertionScope())
         {
             response.Should().NotBeNull();
@@ -1571,7 +1571,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             response.TypenseMemoryRetainedBytes.Should().NotBeNullOrWhiteSpace();
         }
     }
-    
+
     [Fact, TestPriority(31)]
     public async Task Escape_url_parameters()
     {
@@ -1586,25 +1586,25 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "FR"
             },
         };
-    
+
         await _client.CreateDocument<Company>("companies", company);
-    
+
         var query = new SearchParameters("&filter_by=foo", "company_name");
-    
+
         var response = await _client.Search<Company>("companies", query);
-    
+
         using (var scope = new AssertionScope())
         {
             response.Found.Should().Be(1);
             response.Hits.First().Document.Should().BeEquivalentTo(company);
         }
     }
-    
+
     [Fact, TestPriority(32)]
     public async Task Can_do_vector_search()
     {
         const string COLLECTION_NAME = "address_vector_search";
-    
+
         try
         {
             var schema = new Schema(
@@ -1613,9 +1613,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 {
                     new Field("vec", FieldType.FloatArray, 4)
                 });
-    
+
             _ = await _client.CreateCollection(schema);
-    
+
             await _client.CreateDocument(
                 COLLECTION_NAME,
                 new AddressVectorSearch()
@@ -1623,7 +1623,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     Id = "0",
                     Vec = new float[] { 0.04F, 0.234F, 0.113F, 0.001F }
                 });
-    
+
             // We want to make sure the query works using the query object `VectorQuery`
             var queryUsingQueryObject = new MultiSearchParameters(COLLECTION_NAME, "*")
             {
@@ -1633,17 +1633,17 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     vectorFieldName: "vec",
                     k: 100)
             };
-    
+
             // We want to make sure the query works using a query string
             var queryUsingQueryString = new MultiSearchParameters(COLLECTION_NAME, "*")
             {
                 // vec:([0.96826, 0.94, 0.39557, 0.306488], k:100)
                 VectorQuery = new("vec:([0.96826,0.94,0.39557,0.306488],k:100)")
             };
-    
+
             var queryObjectResponse = await _client.MultiSearch<AddressVectorSearch>(queryUsingQueryObject);
             var queryStringResponse = await _client.MultiSearch<AddressVectorSearch>(queryUsingQueryString);
-    
+
             using (var scope = new AssertionScope())
             {
                 queryObjectResponse.Found.Should().Be(1);
@@ -1663,7 +1663,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                             },
                             null,
                             0.19744956493377686));
-    
+
                 queryStringResponse.Found.Should().Be(1);
                 queryStringResponse.OutOf.Should().Be(1);
                 queryStringResponse.Page.Should().Be(1);
@@ -1696,13 +1696,13 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             }
         }
     }
-    
+
     [Fact, TestPriority(32)]
     public async Task Search_against_array_field()
     {
         // Give it a random name, to avoid name clashes.
         var collection_name = $"companies-{Guid.NewGuid()}";
-    
+
         // Setup the schema with a `StringArray` field.
         var schema = new Schema(
             collection_name,
@@ -1717,7 +1717,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         {
             EnableNestedFields = true
         };
-    
+
         var company = new Company
         {
             Id = "124",
@@ -1730,16 +1730,16 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             },
             Aliases = new string[] { "Stark", "Mickey Stark Inc." }
         };
-    
+
         try
         {
             _ = await _client.CreateCollection(schema);
             _ = await _client.UpsertDocument(collection_name, company);
-    
+
             var query = new SearchParameters("Stark", "aliases");
-    
+
             var result = await _client.Search<Company>(collection_name, query);
-    
+
             var expectedHighlight = new Highlight(
                 "aliases",
                 null,
@@ -1756,7 +1756,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new List<int> { 0, 1 },
                 null
             );
-    
+
             using (var scope = new AssertionScope())
             {
                 // Only test for highlight, since it is the one that differs
@@ -1771,12 +1771,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             await _client.DeleteCollection(collection_name);
         }
     }
-    
+
     [Fact, TestPriority(33)]
     public async Task Can_do_semantic_search()
     {
         const string COLLECTION_NAME = "course_vector_search";
-    
+
         try
         {
             var schema = new Schema(
@@ -1789,9 +1789,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                         modelConfig: new ModelConfig("ts/all-MiniLM-L12-v2"))
                     ),
                 });
-    
+
             _ = await _client.CreateCollection(schema);
-    
+
             await _client.CreateDocument(
                 COLLECTION_NAME,
                 new CourseSemanticSearch
@@ -1799,12 +1799,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     Id = "CS101",
                     Title = "Introduction to Programming",
                 });
-    
+
             // We want to make sure the query works using the query object `VectorQuery`
             var queryUsingQueryObject = new MultiSearchParameters(COLLECTION_NAME, "coding", "embedding");
-    
+
             var queryObjectResponse = await _client.MultiSearch<CourseSemanticSearch>(queryUsingQueryObject);
-    
+
             using (var scope = new AssertionScope())
             {
                 queryObjectResponse.Found.Should().Be(1);
@@ -1839,34 +1839,34 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             }
         }
     }
-    
+
     [Fact, TestPriority(34)]
     public async Task Can_retrieve_health()
     {
         var response = await _client.RetrieveHealth();
-    
+
         using (var scope = new AssertionScope())
         {
             response.Ok.Should().BeTrue();
         }
     }
-    
+
     [Fact, TestPriority(35)]
     public async Task Can_create_snapshot()
     {
         var response = await _client.CreateSnapshot("/my_snapshot_path");
-    
+
         using (var scope = new AssertionScope())
         {
             response.Success.Should().BeTrue();
         }
     }
-    
+
     [Fact, TestPriority(36)]
     public async Task Can_compact_disk()
     {
         var response = await _client.CompactDisk();
-    
+
         using (var scope = new AssertionScope())
         {
             response.Success.Should().BeTrue();
@@ -1886,7 +1886,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
 
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     private async Task CreateCompanyCollection()
     {
         var schema = new Schema(

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -119,7 +119,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
 
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(0)]
     public async Task Create_schema_symbols_to_index_and_token_seperator()
     {
@@ -160,7 +160,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<string> { "-" },
             new List<string> { "+" },
             true);
-
+    
         var schema = new Schema(
             "companies_with_symbols_and_token",
             new List<Field>
@@ -175,15 +175,15 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             SymbolsToIndex = new List<string> { "+" },
             EnableNestedFields = true,
         };
-
+    
         var response = await _client.CreateCollection(schema);
-
+    
         response.Should().BeEquivalentTo(expected);
-
+    
         // Cleanup
         await _client.DeleteCollection(schema.Name);
     }
-
+    
     // We test wildcard field individually,
     // because it is a bit different than other types of fields.
     [Fact, TestPriority(0)]
@@ -208,29 +208,29 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<string>(),
             new List<string>(),
             false);
-
+    
         var schema = new Schema(
             "wildcard-collection",
             new List<Field>
             {
                 new Field(".*", FieldType.String, false),
             });
-
+    
         var response = await _client.CreateCollection(schema);
-
+    
         response.Should().BeEquivalentTo(expected);
-
+    
         // Cleanup
         await _client.DeleteCollection("wildcard-collection");
     }
-
+    
     // We test wildcard field individually,
     // because it is a bit different than other types of fields.
     [Fact, TestPriority(0)]
     public async Task Create_schema_with_locale_on_field()
     {
         const string collectionName = "collection-with-locale";
-
+    
         var expected = new CollectionResponse(
             collectionName,
             0,
@@ -251,7 +251,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<string>(),
             new List<string>(),
             false);
-
+    
         var schema = new Schema(
             collectionName,
             new List<Field>
@@ -262,15 +262,15 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     optional: true,
                     locale: "zh"),
             });
-
+    
         var response = await _client.CreateCollection(schema);
-
+    
         response.Should().BeEquivalentTo(expected);
-
+    
         // Cleanup
         await _client.DeleteCollection(collectionName);
     }
-
+    
     [Fact, TestPriority(1)]
     public async Task Retrieve_collection()
     {
@@ -311,12 +311,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<string>(),
             new List<string>(),
             true);
-
+    
         var response = await _client.RetrieveCollection("companies");
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(2)]
     public async Task Retrieve_collections()
     {
@@ -360,11 +360,11 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new List<string>(),
                 true)
         };
-
+    
         var response = await _client.RetrieveCollections();
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(2)]
     public async Task Update_collection()
     {
@@ -375,15 +375,15 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new UpdateSchemaField("non_profit", FieldType.Bool)
             }
         );
-
+    
         var result = await _client.UpdateCollection("companies", updateSchema);
-
+    
         result.Fields.Should().Satisfy(
             e => e.Name == "company_name" && e.Drop == true,
             e => e.Name == "non_profit" && e.Type == FieldType.Bool
         );
     }
-
+    
     [Fact, TestPriority(3)]
     public async Task Delete_collection()
     {
@@ -424,18 +424,18 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<string>(),
             new List<string>(),
             true);
-
+    
         var result = await _client.DeleteCollection("companies");
-
+    
         result.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(4)]
     public async Task Index_document()
     {
         // We create collection for test cases.
         await CreateCompanyCollection();
-
+    
         var company = new Company
         {
             Id = "124",
@@ -447,12 +447,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var response = await _client.CreateDocument<Company>("companies", company);
-
+    
         response.Should().BeEquivalentTo(company);
     }
-
+    
     [Fact, TestPriority(5)]
     public async Task Upsert_document_existing_document()
     {
@@ -467,12 +467,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var response = await _client.UpsertDocument<Company>("companies", company);
-
+    
         response.Should().BeEquivalentTo(company);
     }
-
+    
     [Fact, TestPriority(6)]
     public async Task Upsert_document_new_document()
     {
@@ -487,12 +487,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "SWE"
             },
         };
-
+    
         var response = await _client.UpsertDocument<Company>("companies", company);
-
+    
         response.Should().BeEquivalentTo(company);
     }
-
+    
     [Fact, TestPriority(7)]
     public async Task Import_documents_create()
     {
@@ -501,7 +501,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new ImportResponse(true),
             new ImportResponse(true),
         };
-
+    
         var companies = new List<Company>
         {
             new Company
@@ -527,13 +527,13 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 },
             }
         };
-
+    
         var response = await _client.ImportDocuments<Company>(
             "companies", companies, 40, ImportType.Create);
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(7)]
     public async Task Import_documents_update()
     {
@@ -542,7 +542,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new ImportResponse(true),
             new ImportResponse(true),
         };
-
+    
         var companies = new List<Company>
         {
             new Company
@@ -568,12 +568,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 },
             }
         };
-
+    
         var response = await _client.ImportDocuments<Company>("companies", companies, 40, ImportType.Update);
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(7)]
     public async Task Import_documents_upsert()
     {
@@ -582,7 +582,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new ImportResponse(true),
             new ImportResponse(true),
         };
-
+    
         var companies = new List<Company>
         {
             new Company
@@ -608,13 +608,13 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 },
             }
         };
-
+    
         var response = await _client.ImportDocuments<Company>(
             "companies", companies, 40, ImportType.Upsert);
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(7)]
     public async Task Import_documents_emplace()
     {
@@ -623,7 +623,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new ImportResponse(true),
             new ImportResponse(true),
         };
-
+    
         var companies = new List<Company>
         {
             new Company
@@ -649,13 +649,13 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 },
             }
         };
-
+    
         var response = await _client.ImportDocuments<Company>(
             "companies", companies, 40, ImportType.Emplace);
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(8)]
     public async Task Export_documents()
     {
@@ -706,12 +706,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 },
             }
         };
-
+    
         var response = await _client.ExportDocuments<Company>("companies");
-
+    
         response.OrderBy(x => x.Id).Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(8)]
     public async Task Export_documents_filter_by_query()
     {
@@ -729,12 +729,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 },
             }
         };
-
+    
         var response = await _client.ExportDocuments<Company>("companies", new ExportParameters { FilterBy = "id: [124]" });
-
+    
         response.OrderBy(x => x.Id).Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(8)]
     public async Task Export_documents_include_fields()
     {
@@ -761,12 +761,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 CompanyName = "Awesome A/S"
             }
         };
-
+    
         var response = await _client.ExportDocuments<Company>("companies", new ExportParameters { IncludeFields = "id,company_name" });
-
+    
         response.OrderBy(x => x.Id).Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(8)]
     public async Task Export_documents_exclude_fields()
     {
@@ -813,12 +813,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 },
             }
         };
-
+    
         var response = await _client.ExportDocuments<Company>("companies", new ExportParameters { ExcludeFields = "num_employees" });
-
+    
         response.OrderBy(x => x.Id).Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(9)]
     public async Task Retrieve_document()
     {
@@ -833,12 +833,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var response = await _client.RetrieveDocument<Company>("companies", "124");
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(10)]
     public async Task Update_document()
     {
@@ -853,12 +853,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var response = await _client.UpdateDocument("companies", "124", company);
-
+    
         response.Should().BeEquivalentTo(response);
     }
-
+    
     [Fact, TestPriority(11)]
     public async Task Search_query_by_just_text()
     {
@@ -873,18 +873,18 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var query = new SearchParameters("Stark", "company_name");
-
+    
         var response = await _client.Search<Company>("companies", query);
-
+    
         using (var scope = new AssertionScope())
         {
             response.Found.Should().Be(1);
             response.Hits.First().Document.Should().BeEquivalentTo(expected);
         }
     }
-
+    
     [Fact, TestPriority(11)]
     public async Task Search_query_by_just_text_with_full_search_field()
     {
@@ -899,14 +899,14 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var query = new SearchParameters("Stark", "company_name")
         {
             HighlightFullFields = "company_name"
         };
-
+    
         var response = await _client.Search<Company>("companies", query);
-
+    
         using (var scope = new AssertionScope())
         {
             response.Found.Should().Be(1);
@@ -916,7 +916,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             response.Hits.First().Highlights.First().Value.Should().NotBeNullOrEmpty();
         }
     }
-
+    
     [Fact, TestPriority(11)]
     public async Task Search_query_by_just_text_with_split_join_tokens_set()
     {
@@ -931,21 +931,21 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var query = new SearchParameters("Stark", "company_name")
         {
             SplitJoinTokens = SplitJoinTokenOption.Fallback
         };
-
+    
         var response = await _client.Search<Company>("companies", query);
-
+    
         using (var scope = new AssertionScope())
         {
             response.Found.Should().Be(1);
             response.Hits.First().Document.Should().BeEquivalentTo(expected);
         }
     }
-
+    
     [Fact, TestPriority(11)]
     public async Task Search_query_by_two_fields()
     {
@@ -960,17 +960,17 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var query = new SearchParameters("Stark", "company_name,location.country");
         var response = await _client.Search<Company>("companies", query);
-
+    
         using (var scope = new AssertionScope())
         {
             response.Found.Should().Be(1);
             response.Hits.First().Document.Should().BeEquivalentTo(expected);
         }
     }
-
+    
     [Fact, TestPriority(11)]
     public async Task Search_facet_by_country()
     {
@@ -980,21 +980,21 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new FacetCountHit("SWE", 1, "SWE"),
             new FacetCountHit("USA", 1, "USA"),
         }, new FacetStats(0, 0, 0, 0, 3));
-
+    
         var query = new SearchParameters("", "company_name")
         {
             FacetBy = "location.country"
         };
-
+    
         var response = await _client.Search<Company>("companies", query);
-
+    
         using (var scope = new AssertionScope())
         {
             response.FacetCounts.Should().HaveCount(1);
             response.FacetCounts.First().Should().BeEquivalentTo(expected);
         }
     }
-
+    
     [Fact, TestPriority(11)]
     public async Task Search_facet_by_num_employees()
     {
@@ -1005,21 +1005,21 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new FacetCountHit( "1232", 1, "1232"),
             new FacetCountHit( "6000", 1, "6000"),
         }, new FacetStats(1943.25F, 6000F, 10F, 7773F, 4));
-
+    
         var query = new SearchParameters("", "company_name")
         {
             FacetBy = "num_employees"
         };
-
+    
         var response = await _client.Search<Company>("companies", query);
-
+    
         using (var scope = new AssertionScope())
         {
             response.FacetCounts.Should().HaveCount(1);
             response.FacetCounts.First().Should().BeEquivalentTo(expected);
         }
     }
-
+    
     [Fact, TestPriority(11)]
     public async Task Search_facet_by_country_with_query()
     {
@@ -1027,27 +1027,27 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         {
             new FacetCountHit("USA", 1, "USA"),
         }, new FacetStats(0, 0, 0, 0, 1));
-
+    
         var query = new SearchParameters("Stark", "company_name")
         {
             FacetBy = "location.country"
         };
-
+    
         var response = await _client.Search<Company>("companies", query);
-
+    
         using (var scope = new AssertionScope())
         {
             response.FacetCounts.Should().HaveCount(1);
             response.FacetCounts.First().Should().BeEquivalentTo(expected);
         }
     }
-
+    
     [Fact, TestPriority(11)]
     public async Task Search_grouped_by_country()
     {
         var query = new GroupedSearchParameters("Stark", "company_name", "location.country");
         var response = await _client.SearchGrouped<Company>("companies", query);
-
+    
         using (var scope = new AssertionScope())
         {
             response.Found.Should().Be(1);
@@ -1057,7 +1057,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             firstHit.GroupKey.Should().BeEquivalentTo("USA");
         }
     }
-
+    
     [Fact, TestPriority(11)]
     public async Task Multi_search_query_single_type_multiple_multi_search_parameters()
     {
@@ -1072,7 +1072,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var responses = await _client.MultiSearch<Company>(
             new List<MultiSearchParameters>
             {
@@ -1086,7 +1086,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new MultiSearchParameters("companies", "Stark", "company_name"),
                 new MultiSearchParameters("companies", "Stark", "company_name")
             });
-
+    
         using (var scope = new AssertionScope())
         {
             responses.Count().Should().Be(6);
@@ -1097,7 +1097,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             }
         }
     }
-
+    
     [Fact, TestPriority(11)]
     public async Task Multi_search_query_single_type_multiple_multi_search_parameters_one_failed()
     {
@@ -1112,7 +1112,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var responses = await _client.MultiSearch<Company>(
             new List<MultiSearchParameters>
             {
@@ -1122,17 +1122,17 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new MultiSearchParameters("companies", "Stark", "company_name"),
                 new MultiSearchParameters("this_collection_does_not_exist", "Stark", "company_name"),
             });
-
+    
         using (var scope = new AssertionScope())
         {
             responses.Count().Should().Be(2);
-
+    
             // Validate that first has no errors.
             responses[0].Found.Should().Be(1);
             responses[0].Hits.First().Document.Should().BeEquivalentTo(expected);
             responses[0].ErrorMessage.Should().BeNull();
             responses[0].ErrorCode.Should().BeNull();
-
+    
             // Validate that second has errors.
             responses[1].Found.Should().BeNull();
             responses[1].Hits.Should().BeNull();
@@ -1140,7 +1140,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             responses[1].ErrorCode.Should().Be(404);
         }
     }
-
+    
     [Fact, TestPriority(11)]
     public async Task Multi_search_query_single()
     {
@@ -1155,17 +1155,17 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var query = new MultiSearchParameters("companies", "Stark", "company_name");
         var response = await _client.MultiSearch<Company>(query);
-
+    
         using (var scope = new AssertionScope())
         {
             response.Found.Should().Be(1);
             response.Hits.First().Document.Should().BeEquivalentTo(expected);
         }
     }
-
+    
     [Fact, TestPriority(11)]
     public async Task Multi_search_query_two()
     {
@@ -1180,23 +1180,23 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var query = new MultiSearchParameters("companies", "Stark", "company_name");
-
+    
         // We just use the same for queries for simplicity.
         // We mainly care about multiple queries being returned with the correct types of <T>.
         var (r1, r2) = await _client.MultiSearch<Company, Company>(query, query);
-
+    
         using (var scope = new AssertionScope())
         {
             r1.Found.Should().Be(1);
             r1.Hits.First().Document.Should().BeEquivalentTo(expected);
-
+    
             r2.Found.Should().Be(1);
             r2.Hits.First().Document.Should().BeEquivalentTo(expected);
         }
     }
-
+    
     [Fact, TestPriority(11)]
     public async Task Multi_search_query_three()
     {
@@ -1211,26 +1211,26 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var query = new MultiSearchParameters("companies", "Stark", "company_name");
-
+    
         // We just use the same for queries for simplicity.
         // We mainly care about multiple queries being returned with the correct types of <T>.
         var (r1, r2, r3) = await _client.MultiSearch<Company, Company, Company>(query, query, query);
-
+    
         using (var scope = new AssertionScope())
         {
             r1.Found.Should().Be(1);
             r1.Hits.First().Document.Should().BeEquivalentTo(expected);
-
+    
             r2.Found.Should().Be(1);
             r2.Hits.First().Document.Should().BeEquivalentTo(expected);
-
+    
             r3.Found.Should().Be(1);
             r3.Hits.First().Document.Should().BeEquivalentTo(expected);
         }
     }
-
+    
     [Fact, TestPriority(11)]
     public async Task Multi_search_query_four()
     {
@@ -1245,29 +1245,29 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var query = new MultiSearchParameters("companies", "Stark", "company_name");
-
+    
         // We just use the same for queries for simplicity.
         // We mainly care about multiple queries being returned with the correct types of <T>.
         var (r1, r2, r3, r4) = await _client.MultiSearch<Company, Company, Company, Company>(query, query, query, query);
-
+    
         using (var scope = new AssertionScope())
         {
             r1.Found.Should().Be(1);
             r1.Hits.First().Document.Should().BeEquivalentTo(expected);
-
+    
             r2.Found.Should().Be(1);
             r2.Hits.First().Document.Should().BeEquivalentTo(expected);
-
+    
             r3.Found.Should().Be(1);
             r3.Hits.First().Document.Should().BeEquivalentTo(expected);
-
+    
             r4.Found.Should().Be(1);
             r4.Hits.First().Document.Should().BeEquivalentTo(expected);
         }
     }
-
+    
     [Fact, TestPriority(12)]
     public async Task Delete_document_by_id()
     {
@@ -1282,21 +1282,21 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "USA"
             },
         };
-
+    
         var response = await _client.DeleteDocument<Company>("companies", "124");
-
+    
         response.Should().BeEquivalentTo(response);
     }
-
+    
     [Fact, TestPriority(13)]
     public async Task Delete_document_by_query()
     {
         var expected = new FilterDeleteResponse(2);
         var response = await _client.DeleteDocuments("companies", "num_employees:>100");
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(14)]
     public async Task Create_api_key()
     {
@@ -1308,9 +1308,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             Value = "Example-api-1-key-value",
             ExpiresAt = 1661344547
         };
-
+    
         var response = await _client.CreateKey(expected);
-
+    
         using (var scope = new AssertionScope())
         {
             response.Description.Should().BeEquivalentTo(expected.Description);
@@ -1320,18 +1320,18 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             response.ExpiresAt.Should().Be(expected.ExpiresAt);
         }
     }
-
+    
     [Fact, TestPriority(15)]
     public async Task Retrieve_api_key()
     {
         var apiKeys = await _client.ListKeys();
         var apiKey = apiKeys.Keys.First();
-
+    
         var response = await _client.RetrieveKey(apiKey.Id);
-
+    
         response.Should().BeEquivalentTo(apiKey);
     }
-
+    
     [Fact, TestPriority(16)]
     public async Task List_keys()
     {
@@ -1343,9 +1343,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             Value = "Example-api-1-key-value",
             ExpiresAt = 1661344547
         };
-
+    
         var response = await _client.ListKeys();
-
+    
         response.Keys.Should()
             .HaveCount(1).And
             .SatisfyRespectively(
@@ -1358,7 +1358,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     first.ExpiresAt.Should().Be(expected.ExpiresAt);
                 });
     }
-
+    
     [Fact, TestPriority(17)]
     public async Task Delete_api_key()
     {
@@ -1368,12 +1368,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         {
             Id = apiKey.Id
         };
-
+    
         var response = await _client.DeleteKey(apiKey.Id);
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(18)]
     public async Task Upsert_search_override()
     {
@@ -1386,23 +1386,23 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     new Include("54", 2)
                 },
         };
-
+    
         var response = await _client.UpsertSearchOverride(
             "companies", "customize-apple", searchOverride);
     }
-
+    
     [Fact, TestPriority(19)]
     public async Task Retrive_search_override()
     {
         var searchOverrides = await _client.ListSearchOverrides("companies");
-
+    
         var expected = searchOverrides.SearchOverrides.First();
-
+    
         var response = await _client.RetrieveSearchOverride("companies", expected.Id);
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(20)]
     public async Task List_search_overrides()
     {
@@ -1415,9 +1415,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     new Include("54", 2)
                 },
         };
-
+    
         var response = await _client.ListSearchOverrides("companies");
-
+    
         response.SearchOverrides.Should()
             .HaveCount(1).And
             .SatisfyRespectively(
@@ -1428,29 +1428,29 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     first.Rule.Should().BeEquivalentTo(expected.Rule);
                 });
     }
-
+    
     [Fact, TestPriority(21)]
     public async Task Delete_search_override()
     {
         var expected = new DeleteSearchOverrideResponse("customize-apple");
-
+    
         var response = await _client.DeleteSearchOverride("companies", "customize-apple");
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(22)]
     [Trait("Category", "Integration")]
     public async Task Upsert_collection_alias()
     {
         var expected = new CollectionAliasResponse("companies", "my-companies-alias");
-
+    
         var response = await _client.UpsertCollectionAlias(
             "my-companies-alias", new CollectionAlias("companies"));
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(23)]
     public async Task List_collection_aliases()
     {
@@ -1458,32 +1458,32 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         {
             new CollectionAliasResponse("companies", "my-companies-alias")
         });
-
+    
         var response = await _client.ListCollectionAliases();
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(24)]
     public async Task Retrieve_collection_alias()
     {
         var expected = new CollectionAliasResponse("companies", "my-companies-alias");
-
+    
         var response = await _client.RetrieveCollectionAlias("my-companies-alias");
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(25)]
     public async Task Delete_collection_alias()
     {
         var expected = new CollectionAliasResponse("companies", "my-companies-alias");
-
+    
         var response = await _client.DeleteCollectionAlias("my-companies-alias");
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(26)]
     public async Task Upsert_synonym()
     {
@@ -1492,18 +1492,18 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<string> { "appl", "aple", "apple" },
             "apple",
             new List<string> { "+" });
-
+    
         var schema = new SynonymSchema(new List<string> { "appl", "aple", "apple" })
         {
             Root = "apple",
             SymbolsToIndex = new List<string> { "+" }
         };
-
+    
         var response = await _client.UpsertSynonym("companies", "apple-synonyms", schema);
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(27)]
     public async Task Retrieve_synonym()
     {
@@ -1512,12 +1512,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             new List<string> { "appl", "aple", "apple" },
             "apple",
             new List<string> { "+" });
-
+    
         var response = await _client.RetrieveSynonym("companies", "apple-synonyms");
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(28)]
     public async Task List_synonyms()
     {
@@ -1530,26 +1530,26 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     "apple",
                     new List<string> { "+" })
             });
-
+    
         var response = await _client.ListSynonyms("companies");
-
+    
         response.Should().BeEquivalentTo(expected);
     }
-
+    
     [Fact, TestPriority(29)]
     public async Task Delete_synonym()
     {
         var expected = new DeleteSynonymResponse("apple-synonyms");
         var response = await _client.DeleteSynonym("companies", "apple-synonyms");
-
+    
         response.Should().Be(expected);
     }
-
+    
     [Fact, TestPriority(30)]
     public async Task Can_retrieve_metrics()
     {
         var response = await _client.RetrieveMetrics();
-
+    
         using (var scope = new AssertionScope())
         {
             response.Should().NotBeNull();
@@ -1571,7 +1571,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             response.TypenseMemoryRetainedBytes.Should().NotBeNullOrWhiteSpace();
         }
     }
-
+    
     [Fact, TestPriority(31)]
     public async Task Escape_url_parameters()
     {
@@ -1586,25 +1586,25 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 Country = "FR"
             },
         };
-
+    
         await _client.CreateDocument<Company>("companies", company);
-
+    
         var query = new SearchParameters("&filter_by=foo", "company_name");
-
+    
         var response = await _client.Search<Company>("companies", query);
-
+    
         using (var scope = new AssertionScope())
         {
             response.Found.Should().Be(1);
             response.Hits.First().Document.Should().BeEquivalentTo(company);
         }
     }
-
+    
     [Fact, TestPriority(32)]
     public async Task Can_do_vector_search()
     {
         const string COLLECTION_NAME = "address_vector_search";
-
+    
         try
         {
             var schema = new Schema(
@@ -1613,9 +1613,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 {
                     new Field("vec", FieldType.FloatArray, 4)
                 });
-
+    
             _ = await _client.CreateCollection(schema);
-
+    
             await _client.CreateDocument(
                 COLLECTION_NAME,
                 new AddressVectorSearch()
@@ -1623,7 +1623,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     Id = "0",
                     Vec = new float[] { 0.04F, 0.234F, 0.113F, 0.001F }
                 });
-
+    
             // We want to make sure the query works using the query object `VectorQuery`
             var queryUsingQueryObject = new MultiSearchParameters(COLLECTION_NAME, "*")
             {
@@ -1633,17 +1633,17 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     vectorFieldName: "vec",
                     k: 100)
             };
-
+    
             // We want to make sure the query works using a query string
             var queryUsingQueryString = new MultiSearchParameters(COLLECTION_NAME, "*")
             {
                 // vec:([0.96826, 0.94, 0.39557, 0.306488], k:100)
                 VectorQuery = new("vec:([0.96826,0.94,0.39557,0.306488],k:100)")
             };
-
+    
             var queryObjectResponse = await _client.MultiSearch<AddressVectorSearch>(queryUsingQueryObject);
             var queryStringResponse = await _client.MultiSearch<AddressVectorSearch>(queryUsingQueryString);
-
+    
             using (var scope = new AssertionScope())
             {
                 queryObjectResponse.Found.Should().Be(1);
@@ -1663,7 +1663,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                             },
                             null,
                             0.19744956493377686));
-
+    
                 queryStringResponse.Found.Should().Be(1);
                 queryStringResponse.OutOf.Should().Be(1);
                 queryStringResponse.Page.Should().Be(1);
@@ -1696,13 +1696,13 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             }
         }
     }
-
+    
     [Fact, TestPriority(32)]
     public async Task Search_against_array_field()
     {
         // Give it a random name, to avoid name clashes.
         var collection_name = $"companies-{Guid.NewGuid()}";
-
+    
         // Setup the schema with a `StringArray` field.
         var schema = new Schema(
             collection_name,
@@ -1717,7 +1717,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         {
             EnableNestedFields = true
         };
-
+    
         var company = new Company
         {
             Id = "124",
@@ -1730,16 +1730,16 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             },
             Aliases = new string[] { "Stark", "Mickey Stark Inc." }
         };
-
+    
         try
         {
             _ = await _client.CreateCollection(schema);
             _ = await _client.UpsertDocument(collection_name, company);
-
+    
             var query = new SearchParameters("Stark", "aliases");
-
+    
             var result = await _client.Search<Company>(collection_name, query);
-
+    
             var expectedHighlight = new Highlight(
                 "aliases",
                 null,
@@ -1756,7 +1756,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 new List<int> { 0, 1 },
                 null
             );
-
+    
             using (var scope = new AssertionScope())
             {
                 // Only test for highlight, since it is the one that differs
@@ -1771,12 +1771,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             await _client.DeleteCollection(collection_name);
         }
     }
-
+    
     [Fact, TestPriority(33)]
     public async Task Can_do_semantic_search()
     {
         const string COLLECTION_NAME = "course_vector_search";
-
+    
         try
         {
             var schema = new Schema(
@@ -1789,9 +1789,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                         modelConfig: new ModelConfig("ts/all-MiniLM-L12-v2"))
                     ),
                 });
-
+    
             _ = await _client.CreateCollection(schema);
-
+    
             await _client.CreateDocument(
                 COLLECTION_NAME,
                 new CourseSemanticSearch
@@ -1799,12 +1799,12 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     Id = "CS101",
                     Title = "Introduction to Programming",
                 });
-
+    
             // We want to make sure the query works using the query object `VectorQuery`
             var queryUsingQueryObject = new MultiSearchParameters(COLLECTION_NAME, "coding", "embedding");
-
+    
             var queryObjectResponse = await _client.MultiSearch<CourseSemanticSearch>(queryUsingQueryObject);
-
+    
             using (var scope = new AssertionScope())
             {
                 queryObjectResponse.Found.Should().Be(1);
@@ -1839,38 +1839,52 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             }
         }
     }
-
+    
     [Fact, TestPriority(34)]
     public async Task Can_retrieve_health()
     {
         var response = await _client.RetrieveHealth();
-
+    
         using (var scope = new AssertionScope())
         {
             response.Ok.Should().BeTrue();
         }
     }
-
+    
     [Fact, TestPriority(35)]
     public async Task Can_create_snapshot()
     {
         var response = await _client.CreateSnapshot("/my_snapshot_path");
-
+    
+        using (var scope = new AssertionScope())
+        {
+            response.Success.Should().BeTrue();
+        }
+    }
+    
+    [Fact, TestPriority(36)]
+    public async Task Can_compact_disk()
+    {
+        var response = await _client.CompactDisk();
+    
         using (var scope = new AssertionScope())
         {
             response.Success.Should().BeTrue();
         }
     }
 
-    [Fact, TestPriority(36)]
-    public async Task Can_compact_disk()
+    [Fact, TestPriority(37)]
+    public async Task Update_document_by_query()
     {
-        var response = await _client.CompactDisk();
-
-        using (var scope = new AssertionScope())
+        var document = new
         {
-            response.Success.Should().BeTrue();
-        }
+            CompanyName = "Dom Bomb Dot Com",
+        };
+        
+        var expected = new FilterUpdateResponse(1);
+        var response = await _client.UpdateDocuments("companies", document, "num_employees:>100");
+
+        response.Should().BeEquivalentTo(expected);
     }
 
     private async Task CreateCompanyCollection()


### PR DESCRIPTION
Adding a function to allow updating of all documents in a collection that match a supplied filter.

https://typesense.org/docs/0.25.2/api/documents.html#update-by-query

Output From Test.

![image](https://github.com/DAXGRID/typesense-dotnet/assets/105202941/13429540-25ad-4c0b-a533-73415f347924)

Please let me know if there are any issues or suggested improvements.

This would be very beneficial to the project I am working on as it will allow us to do some better targeted updates.
