### PR TITLE
Support parsing & serialization of vectors in locales that use comma as decimal separator

### DIFF
--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -1629,7 +1629,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             {
                 // vec:([0.96826, 0.94, 0.39557, 0.306488], k:100)
                 VectorQuery = new(
-                    vector: new float[] { 0.96826F, 0.94F, 0.39557F, 0.306488F },
+                    vector: [0.96826F, 0.94F, 0.39557F, 0.306488F],
                     vectorFieldName: "vec",
                     k: 100)
             };
@@ -1638,7 +1638,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             var queryUsingQueryString = new MultiSearchParameters(COLLECTION_NAME, "*")
             {
                 // vec:([0.96826, 0.94, 0.39557, 0.306488], k:100)
-                VectorQuery = new("vec:([0.96826,0.94,0.39557,0.306488],k:100)")
+                VectorQuery = new("vec:([ 0.96826 , 0.94    ,   0.39557,0.306488],  k : 100 )")
             };
 
             var queryObjectResponse = await _client.MultiSearch<AddressVectorSearch>(queryUsingQueryObject);


### PR DESCRIPTION
`Can_do_vector_search` test failed on my machine.  
The reason is that I am running da-DK locale, where comma is used as decimal separator.  
This has been fixed by using InvariantCulture when parsing & serializing floats to strings.

As part of this fix I also changed the ToQuery to use a StringBuilder instead of string concattenation, string.Joins and an allocated list, this should also have a positive effect on performance & reduced GC.

The vector string parsing was improved by reusing a compiled Regex, instead of instantiating a new Regex for every parse.  
Instead of trimming & removing empty string after Split, the built in StringSplitOptions are used, resulting in less LINQ, less allocations of Lists & arrays, and faster iteration of an array, compared to iterating the allocated List.  
Single char string Splits has been replaced by splitting on just the char, which is slightly more efficient.  

I have added tabs and spaces to the parsed string vector in the unit test to validate my changes to the parsing.