### PR TITLE
Reuse JsonSerializerOptions, they are thread safe. Fix typo

### DIFF
--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -19,8 +19,8 @@ namespace Typesense;
 public class TypesenseClient : ITypesenseClient
 {
     private readonly HttpClient _httpClient;
-    private readonly JsonSerializerOptions _jsonNameCaseInsentiveTrue = new() { PropertyNameCaseInsensitive = true };
-    private readonly JsonSerializerOptions _jsonOptionsCamelCaseIgnoreWritingNull = new()
+    private static readonly JsonSerializerOptions JsonNameCaseInsensitiveTrue = new() { PropertyNameCaseInsensitive = true };
+    private static readonly JsonSerializerOptions JsonOptionsCamelCaseIgnoreWritingNull = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
@@ -41,7 +41,7 @@ public class TypesenseClient : ITypesenseClient
     {
         ArgumentNullException.ThrowIfNull(schema);
 
-        var json = JsonSerializer.Serialize(schema, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var json = JsonSerializer.Serialize(schema, JsonOptionsCamelCaseIgnoreWritingNull);
         return Post<CollectionResponse>("/collections", json, jsonSerializerOptions: null);
     }
 
@@ -52,14 +52,14 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(document))
             throw new ArgumentException("Cannot be null empty or whitespace", nameof(document));
 
-        return Post<T>($"/collections/{collection}/documents", document, _jsonNameCaseInsentiveTrue);
+        return Post<T>($"/collections/{collection}/documents", document, JsonNameCaseInsensitiveTrue);
     }
 
     public async Task<T> CreateDocument<T>(string collection, T document) where T : class
     {
         ArgumentNullException.ThrowIfNull(document);
 
-        var json = JsonSerializer.Serialize(document, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var json = JsonSerializer.Serialize(document, JsonOptionsCamelCaseIgnoreWritingNull);
         return await CreateDocument<T>(collection, json).ConfigureAwait(false);
     }
 
@@ -70,14 +70,14 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(document))
             throw new ArgumentException("cannot be null empty or whitespace", nameof(document));
 
-        return Post<T>($"/collections/{collection}/documents?action=upsert", document, _jsonNameCaseInsentiveTrue);
+        return Post<T>($"/collections/{collection}/documents?action=upsert", document, JsonNameCaseInsensitiveTrue);
     }
 
     public async Task<T> UpsertDocument<T>(string collection, T document) where T : class
     {
         ArgumentNullException.ThrowIfNull(document);
 
-        var json = JsonSerializer.Serialize(document, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var json = JsonSerializer.Serialize(document, JsonOptionsCamelCaseIgnoreWritingNull);
         return await UpsertDocument<T>(collection, json);
     }
 
@@ -90,7 +90,7 @@ public class TypesenseClient : ITypesenseClient
         ArgumentNullException.ThrowIfNull(searchParameters);
 
         var parameters = CreateUrlParameters(searchParameters);
-        return Get<TResult>($"/collections/{collection}/documents/search?{parameters}", _jsonNameCaseInsentiveTrue, ctk);
+        return Get<TResult>($"/collections/{collection}/documents/search?{parameters}", JsonNameCaseInsensitiveTrue, ctk);
     }
 
     public async Task<SearchResult<T>> Search<T>(string collection, SearchParameters searchParameters, CancellationToken ctk = default)
@@ -106,7 +106,7 @@ public class TypesenseClient : ITypesenseClient
     public async Task<List<MultiSearchResult<T>>> MultiSearch<T>(ICollection<MultiSearchParameters> s1, int? limitMultiSearches = null, CancellationToken ctk = default)
     {
         var searches = new { Searches = s1 };
-        var json = JsonSerializer.Serialize(searches, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var json = JsonSerializer.Serialize(searches, JsonOptionsCamelCaseIgnoreWritingNull);
 
         var path = limitMultiSearches is null
             ? "/multi_search"
@@ -122,7 +122,7 @@ public class TypesenseClient : ITypesenseClient
     public async Task<MultiSearchResult<T>> MultiSearch<T>(MultiSearchParameters s1, CancellationToken ctk = default)
     {
         var searches = new { Searches = new MultiSearchParameters[] { s1 } };
-        var json = JsonSerializer.Serialize(searches, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var json = JsonSerializer.Serialize(searches, JsonOptionsCamelCaseIgnoreWritingNull);
         var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
         return response.TryGetProperty("results", out var results)
@@ -133,7 +133,7 @@ public class TypesenseClient : ITypesenseClient
     public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>)> MultiSearch<T1, T2>(MultiSearchParameters s1, MultiSearchParameters s2, CancellationToken ctk = default)
     {
         var searches = new { Searches = new MultiSearchParameters[] { s1, s2 } };
-        var json = JsonSerializer.Serialize(searches, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var json = JsonSerializer.Serialize(searches, JsonOptionsCamelCaseIgnoreWritingNull);
         var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
         return response.TryGetProperty("results", out var results)
@@ -149,7 +149,7 @@ public class TypesenseClient : ITypesenseClient
         CancellationToken ctk = default)
     {
         var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3 } };
-        var json = JsonSerializer.Serialize(searches, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var json = JsonSerializer.Serialize(searches, JsonOptionsCamelCaseIgnoreWritingNull);
         var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
         return response.TryGetProperty("results", out var results)
@@ -167,7 +167,7 @@ public class TypesenseClient : ITypesenseClient
         CancellationToken ctk = default)
     {
         var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4 } };
-        var json = JsonSerializer.Serialize(searches, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var json = JsonSerializer.Serialize(searches, JsonOptionsCamelCaseIgnoreWritingNull);
         var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
         return (response.TryGetProperty("results", out var results))
@@ -185,7 +185,7 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(id))
             throw new ArgumentException("cannot be null empty or whitespace", nameof(id));
 
-        return Get<T>($"/collections/{collection}/documents/{id}", _jsonNameCaseInsentiveTrue, ctk);
+        return Get<T>($"/collections/{collection}/documents/{id}", JsonNameCaseInsensitiveTrue, ctk);
     }
 
     public Task<T> UpdateDocument<T>(string collection, string id, string document) where T : class
@@ -195,14 +195,14 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(document))
             throw new ArgumentException("Cannot be null empty or whitespace", nameof(document));
 
-        return Patch<T>($"collections/{collection}/documents/{id}", document, _jsonNameCaseInsentiveTrue);
+        return Patch<T>($"collections/{collection}/documents/{id}", document, JsonNameCaseInsensitiveTrue);
     }
 
     public async Task<T> UpdateDocument<T>(string collection, string id, T document) where T : class
     {
         ArgumentNullException.ThrowIfNull(document);
 
-        var json = JsonSerializer.Serialize(document, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var json = JsonSerializer.Serialize(document, JsonOptionsCamelCaseIgnoreWritingNull);
         return await UpdateDocument<T>(collection, id, json).ConfigureAwait(false);
     }
 
@@ -226,7 +226,7 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(documentId))
             throw new ArgumentException("cannot be null empty or whitespace", nameof(documentId));
 
-        return Delete<T>($"/collections/{collection}/documents/{documentId}", _jsonNameCaseInsentiveTrue);
+        return Delete<T>($"/collections/{collection}/documents/{documentId}", JsonNameCaseInsensitiveTrue);
     }
 
     public Task<FilterDeleteResponse> DeleteDocuments(string collection, string filter, int batchSize = 40)
@@ -238,7 +238,7 @@ public class TypesenseClient : ITypesenseClient
         if (batchSize < 0)
             throw new ArgumentException("has to be greater than 0", nameof(batchSize));
 
-        return Delete<FilterDeleteResponse>($"/collections/{collection}/documents?filter_by={Uri.EscapeDataString(filter)}&batch_size={batchSize}", _jsonNameCaseInsentiveTrue);
+        return Delete<FilterDeleteResponse>($"/collections/{collection}/documents?filter_by={Uri.EscapeDataString(filter)}&batch_size={batchSize}", JsonNameCaseInsensitiveTrue);
     }
 
     public Task<CollectionResponse> DeleteCollection(string name)
@@ -246,7 +246,7 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException("cannot be null empty or whitespace", nameof(name));
 
-        return Delete<CollectionResponse>($"/collections/{name}", _jsonNameCaseInsentiveTrue);
+        return Delete<CollectionResponse>($"/collections/{name}", JsonNameCaseInsensitiveTrue);
     }
 
     public Task<UpdateCollectionResponse> UpdateCollection(
@@ -258,9 +258,9 @@ public class TypesenseClient : ITypesenseClient
 
         var json = JsonSerializer.Serialize(
             updateSchema,
-            _jsonOptionsCamelCaseIgnoreWritingNull);
+            JsonOptionsCamelCaseIgnoreWritingNull);
 
-        return Patch<UpdateCollectionResponse>($"/collections/{name}", json, _jsonNameCaseInsentiveTrue);
+        return Patch<UpdateCollectionResponse>($"/collections/{name}", json, JsonNameCaseInsensitiveTrue);
     }
 
     public Task<FilterUpdateResponse> UpdateDocuments<T>(string collection, T document, string filter)
@@ -272,9 +272,9 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(filter))
             throw new ArgumentException("cannot be null empty or whitespace", nameof(filter));
     
-        var json = JsonSerializer.Serialize(document, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var json = JsonSerializer.Serialize(document, JsonOptionsCamelCaseIgnoreWritingNull);
     
-        return Patch<FilterUpdateResponse>($"collections/{collection}/documents?filter_by={Uri.EscapeDataString(filter)}&action=update", json, _jsonNameCaseInsentiveTrue);
+        return Patch<FilterUpdateResponse>($"collections/{collection}/documents?filter_by={Uri.EscapeDataString(filter)}&action=update", json, JsonNameCaseInsensitiveTrue);
     }
 
     public async Task<List<ImportResponse>> ImportDocuments<T>(
@@ -335,7 +335,7 @@ public class TypesenseClient : ITypesenseClient
     {
         ArgumentNullException.ThrowIfNull(documents);
 
-        var jsonNewlines = JsonNewLines(documents, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var jsonNewlines = JsonNewLines(documents, JsonOptionsCamelCaseIgnoreWritingNull);
         return await ImportDocuments<T>(collection, jsonNewlines, batchSize, importType, remoteEmbeddingBatchSize).ConfigureAwait(false);
     }
 
@@ -356,7 +356,7 @@ public class TypesenseClient : ITypesenseClient
 
         return response.Split('\n')
             .Where(x => !string.IsNullOrWhiteSpace(x))
-            .Select((x) => JsonSerializer.Deserialize<T>(x, _jsonNameCaseInsentiveTrue)
+            .Select((x) => JsonSerializer.Deserialize<T>(x, JsonNameCaseInsensitiveTrue)
                     ?? throw new ArgumentException("Null is not valid for documents"))
             .ToList();
     }
@@ -365,23 +365,23 @@ public class TypesenseClient : ITypesenseClient
     {
         ArgumentNullException.ThrowIfNull(key);
 
-        var json = JsonSerializer.Serialize(key, _jsonOptionsCamelCaseIgnoreWritingNull);
-        return Post<KeyResponse>($"/keys", json, _jsonNameCaseInsentiveTrue);
+        var json = JsonSerializer.Serialize(key, JsonOptionsCamelCaseIgnoreWritingNull);
+        return Post<KeyResponse>($"/keys", json, JsonNameCaseInsensitiveTrue);
     }
 
     public Task<KeyResponse> RetrieveKey(int id, CancellationToken ctk = default)
     {
-        return Get<KeyResponse>($"/keys/{id}", _jsonNameCaseInsentiveTrue, ctk);
+        return Get<KeyResponse>($"/keys/{id}", JsonNameCaseInsensitiveTrue, ctk);
     }
 
     public Task<DeleteKeyResponse> DeleteKey(int id)
     {
-        return Delete<DeleteKeyResponse>($"/keys/{id}", _jsonNameCaseInsentiveTrue);
+        return Delete<DeleteKeyResponse>($"/keys/{id}", JsonNameCaseInsensitiveTrue);
     }
 
     public Task<ListKeysResponse> ListKeys(CancellationToken ctk = default)
     {
-        return Get<ListKeysResponse>($"/keys", _jsonNameCaseInsentiveTrue, ctk);
+        return Get<ListKeysResponse>($"/keys", JsonNameCaseInsensitiveTrue, ctk);
     }
 
     public string GenerateScopedSearchKey(string securityKey, string parameters)
@@ -413,8 +413,8 @@ public class TypesenseClient : ITypesenseClient
 
         ArgumentNullException.ThrowIfNull(searchOverride);
 
-        var json = JsonSerializer.Serialize(searchOverride, _jsonOptionsCamelCaseIgnoreWritingNull);
-        return Put<SearchOverrideResponse>($"/collections/{collection}/overrides/{overrideName}", json, _jsonNameCaseInsentiveTrue);
+        var json = JsonSerializer.Serialize(searchOverride, JsonOptionsCamelCaseIgnoreWritingNull);
+        return Put<SearchOverrideResponse>($"/collections/{collection}/overrides/{overrideName}", json, JsonNameCaseInsensitiveTrue);
     }
 
     public Task<ListSearchOverridesResponse> ListSearchOverrides(string collection, CancellationToken ctk = default)
@@ -422,7 +422,7 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(collection))
             throw new ArgumentException("cannot be null, empty or whitespace.", nameof(collection));
 
-        return Get<ListSearchOverridesResponse>($"collections/{collection}/overrides", _jsonNameCaseInsentiveTrue, ctk);
+        return Get<ListSearchOverridesResponse>($"collections/{collection}/overrides", JsonNameCaseInsensitiveTrue, ctk);
     }
 
     public Task<SearchOverrideResponse> RetrieveSearchOverride(string collection, string overrideName, CancellationToken ctk = default)
@@ -432,7 +432,7 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(overrideName))
             throw new ArgumentException("cannot be null, empty or whitespace.", nameof(overrideName));
 
-        return Get<SearchOverrideResponse>($"/collections/{collection}/overrides/{overrideName}", _jsonNameCaseInsentiveTrue, ctk);
+        return Get<SearchOverrideResponse>($"/collections/{collection}/overrides/{overrideName}", JsonNameCaseInsensitiveTrue, ctk);
     }
 
     public Task<DeleteSearchOverrideResponse> DeleteSearchOverride(
@@ -443,7 +443,7 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(overrideName))
             throw new ArgumentException("cannot be null, empty or whitespace.", nameof(overrideName));
 
-        return Delete<DeleteSearchOverrideResponse>($"/collections/{collection}/overrides/{overrideName}", _jsonNameCaseInsentiveTrue);
+        return Delete<DeleteSearchOverrideResponse>($"/collections/{collection}/overrides/{overrideName}", JsonNameCaseInsensitiveTrue);
     }
 
     public Task<CollectionAliasResponse> UpsertCollectionAlias(string aliasName, CollectionAlias collectionAlias)
@@ -453,8 +453,8 @@ public class TypesenseClient : ITypesenseClient
 
         ArgumentNullException.ThrowIfNull(collectionAlias);
 
-        var json = JsonSerializer.Serialize(collectionAlias, _jsonOptionsCamelCaseIgnoreWritingNull);
-        return Put<CollectionAliasResponse>($"/aliases/{aliasName}", json, _jsonNameCaseInsentiveTrue);
+        var json = JsonSerializer.Serialize(collectionAlias, JsonOptionsCamelCaseIgnoreWritingNull);
+        return Put<CollectionAliasResponse>($"/aliases/{aliasName}", json, JsonNameCaseInsensitiveTrue);
     }
 
     public Task<CollectionAliasResponse> RetrieveCollectionAlias(string collection, CancellationToken ctk = default)
@@ -462,12 +462,12 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(collection))
             throw new ArgumentException("cannot be null or whitespace.", nameof(collection));
 
-        return Get<CollectionAliasResponse>($"/aliases/{collection}", _jsonNameCaseInsentiveTrue, ctk);
+        return Get<CollectionAliasResponse>($"/aliases/{collection}", JsonNameCaseInsensitiveTrue, ctk);
     }
 
     public Task<ListCollectionAliasesResponse> ListCollectionAliases(CancellationToken ctk = default)
     {
-        return Get<ListCollectionAliasesResponse>("/aliases", _jsonNameCaseInsentiveTrue, ctk);
+        return Get<ListCollectionAliasesResponse>("/aliases", JsonNameCaseInsensitiveTrue, ctk);
     }
 
     public Task<CollectionAliasResponse> DeleteCollectionAlias(string aliasName)
@@ -475,7 +475,7 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(aliasName))
             throw new ArgumentException("cannot be null or whitespace.", nameof(aliasName));
 
-        return Delete<CollectionAliasResponse>($"/aliases/{aliasName}", _jsonNameCaseInsentiveTrue);
+        return Delete<CollectionAliasResponse>($"/aliases/{aliasName}", JsonNameCaseInsensitiveTrue);
     }
 
     public Task<SynonymSchemaResponse> UpsertSynonym(
@@ -488,8 +488,8 @@ public class TypesenseClient : ITypesenseClient
 
         ArgumentNullException.ThrowIfNull(schema);
 
-        var json = JsonSerializer.Serialize(schema, _jsonOptionsCamelCaseIgnoreWritingNull);
-        return Put<SynonymSchemaResponse>($"/collections/{collection}/synonyms/{synonym}", json, _jsonNameCaseInsentiveTrue);
+        var json = JsonSerializer.Serialize(schema, JsonOptionsCamelCaseIgnoreWritingNull);
+        return Put<SynonymSchemaResponse>($"/collections/{collection}/synonyms/{synonym}", json, JsonNameCaseInsensitiveTrue);
     }
 
     public Task<SynonymSchemaResponse> RetrieveSynonym(string collection, string synonym, CancellationToken ctk = default)
@@ -499,7 +499,7 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(synonym))
             throw new ArgumentException($"{nameof(synonym)} cannot be null, empty or whitespace.");
 
-        return Get<SynonymSchemaResponse>($"/collections/{collection}/synonyms/{synonym}", _jsonNameCaseInsentiveTrue, ctk);
+        return Get<SynonymSchemaResponse>($"/collections/{collection}/synonyms/{synonym}", JsonNameCaseInsensitiveTrue, ctk);
     }
 
     public Task<ListSynonymsResponse> ListSynonyms(string collection, CancellationToken ctk = default)
@@ -507,7 +507,7 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(collection))
             throw new ArgumentException($"{nameof(collection)} cannot be null, empty or whitespace.");
 
-        return Get<ListSynonymsResponse>($"/collections/{collection}/synonyms", _jsonNameCaseInsentiveTrue, ctk);
+        return Get<ListSynonymsResponse>($"/collections/{collection}/synonyms", JsonNameCaseInsensitiveTrue, ctk);
     }
 
     public Task<DeleteSynonymResponse> DeleteSynonym(string collection, string synonym)
@@ -517,7 +517,7 @@ public class TypesenseClient : ITypesenseClient
         if (string.IsNullOrWhiteSpace(synonym))
             throw new ArgumentException($"{nameof(synonym)} cannot be null, empty or whitespace.");
 
-        return Delete<DeleteSynonymResponse>($"/collections/{collection}/synonyms/{synonym}", _jsonNameCaseInsentiveTrue);
+        return Delete<DeleteSynonymResponse>($"/collections/{collection}/synonyms/{synonym}", JsonNameCaseInsensitiveTrue);
     }
 
     public Task<MetricsResponse> RetrieveMetrics(CancellationToken ctk = default)
@@ -542,12 +542,12 @@ public class TypesenseClient : ITypesenseClient
                 "The snapshot path must not be null, empty or consist of whitespace characters only.",
                 nameof(snapshotPath));
 
-        return Post<SnapshotResponse>($"/operations/snapshot?snapshot_path={Uri.EscapeDataString(snapshotPath)}", httpContent: null, _jsonNameCaseInsentiveTrue, ctk);
+        return Post<SnapshotResponse>($"/operations/snapshot?snapshot_path={Uri.EscapeDataString(snapshotPath)}", httpContent: null, JsonNameCaseInsensitiveTrue, ctk);
     }
 
     public Task<CompactDiskResponse> CompactDisk(CancellationToken ctk = default)
     {
-        return Post<CompactDiskResponse>("/operations/db/compact", httpContent: null, _jsonNameCaseInsentiveTrue, ctk);
+        return Post<CompactDiskResponse>("/operations/db/compact", httpContent: null, JsonNameCaseInsensitiveTrue, ctk);
     }
 
     private static string CreateUrlParameters<T>(T queryParameters)
@@ -685,6 +685,6 @@ public class TypesenseClient : ITypesenseClient
         => JsonNewLines(documents.Select(x => JsonSerializer.Serialize(x, jsonOptions)));
 
     private MultiSearchResult<T> HandleDeserializeMultiSearch<T>(JsonElement jsonElement)
-        => jsonElement.Deserialize<MultiSearchResult<T>>(_jsonNameCaseInsentiveTrue)
+        => jsonElement.Deserialize<MultiSearchResult<T>>(JsonNameCaseInsensitiveTrue)
         ?? throw new InvalidOperationException($"Could not deserialize {typeof(T)}, Received following from Typesense: '{jsonElement}'.");
 }


### PR DESCRIPTION
Microsoft encourages reuse of JsonSerializerOptions, as they are thread safe  
https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/configure-options?pivots=dotnet-8-0#reuse-jsonserializeroptions-instances

By doing that, we avoid allocating & garbage collecting two JsonSerializerOptions for every TypesenseClient created.  
If TypesenseClient is setup as scoped (as in the Test project) in a web API, a TypesenseClient is created for every request.

A typo was also fixed, as I was changing the field name anyway.