### PR TITLE
Use higher HTTP version when possible

### DIFF
--- a/src/Typesense/Setup/TypesenseExtension.cs
+++ b/src/Typesense/Setup/TypesenseExtension.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Net;
 
 namespace Typesense.Setup;
 
@@ -13,7 +14,10 @@ public static class TypesenseExtension
 
         return serviceCollection
             .AddScoped<ITypesenseClient, TypesenseClient>()
-            .AddHttpClient<ITypesenseClient, TypesenseClient>().Services
+            .AddHttpClient<ITypesenseClient, TypesenseClient>(client =>
+            {
+                client.DefaultRequestVersion = HttpVersion.Version30;
+            }).Services
             .Configure(config);
     }
 }


### PR DESCRIPTION
If protocol is http, version 1.1 will be used. I the runtime only can provide 2.0, then that will be used.