### PR TITLE
Add option to enable HTTP compression to lower response times and reduce traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Feel free to make issues or create pull requests if you find any bugs or there a
 
 ## Setup
 
-Setup in service collection so it can be dependency injected. The `AddTypesenseClient` can be found in the `Typesense.Setup` namespace. Remember to change the settings to match your Typesense service. Right now you can specify multiple nodes, but the implementation has not been completed yet, so if you want to use this for multiple nodes, then put a load balancer in front of your services and point the settings to your load balancer.
+Setup in service collection so it can be dependency injected. The `AddTypesenseClient` can be found in the `Typesense.Setup` namespace. Remember to change the settings to match your Typesense service. Right now you can specify multiple nodes, but the implementation has not been completed yet, so if you want to use this for multiple nodes, then put a load balancer in front of your services and point the settings to your load balancer.  
+If you are using externally hosted Typesense, like Typesense Cloud, it is recommended to enable HTTP compression to lower response times and reduce traffic.
 
 ```c#
 var provider = new ServiceCollection()
@@ -19,7 +20,7 @@ var provider = new ServiceCollection()
         {
             new Node("localhost", "8108", "http")
         };
-    }).BuildServiceProvider();
+    }, enableHttpCompression: false).BuildServiceProvider();
 ```
 
 After that you can get it from the `provider` instance or dependency inject it.

--- a/src/Typesense/Setup/TypesenseExtension.cs
+++ b/src/Typesense/Setup/TypesenseExtension.cs
@@ -1,23 +1,35 @@
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Net;
+using System.Net.Http;
 
 namespace Typesense.Setup;
 
 public static class TypesenseExtension
 {
+    /// <param name="enableHttpCompression">
+    /// If set to true, HTTP compression is enabled, lowering response times & reducing traffic for externally hosted Typesense, like Typesense Cloud
+    /// Set to false by default to mimic the old behavior, and not add compression processing overhead on locally hosted Typesense
+    /// </param>
     /// <exception cref="ArgumentNullException"></exception>
-    public static IServiceCollection AddTypesenseClient(this IServiceCollection serviceCollection, Action<Config> config)
+    public static IServiceCollection AddTypesenseClient(this IServiceCollection serviceCollection, Action<Config> config, bool enableHttpCompression = false)
     {
         if (config == null)
             throw new ArgumentNullException(nameof(config), $"Please provide options for TypesenseClient.");
 
-        return serviceCollection
+        var httpClientBuilder = serviceCollection
             .AddScoped<ITypesenseClient, TypesenseClient>()
             .AddHttpClient<ITypesenseClient, TypesenseClient>(client =>
             {
                 client.DefaultRequestVersion = HttpVersion.Version30;
-            }).Services
+            });
+        if (enableHttpCompression)
+            httpClientBuilder = httpClientBuilder
+                .ConfigurePrimaryHttpMessageHandler(_ => new HttpClientHandler
+                {
+                    AutomaticDecompression = DecompressionMethods.All
+                });
+        return httpClientBuilder.Services
             .Configure(config);
     }
 }

--- a/test/Typesense.Tests/TypesenseFixture.cs
+++ b/test/Typesense.Tests/TypesenseFixture.cs
@@ -55,7 +55,7 @@ public class TypesenseFixture : IAsyncLifetime
                 {
                     new Node("localhost", "8108", "http")
                 };
-            }).BuildServiceProvider().GetService<ITypesenseClient>();
+            }, enableHttpCompression: true).BuildServiceProvider().GetService<ITypesenseClient>();
     }
 
     public Task DisposeAsync()


### PR DESCRIPTION
When hosting Typesense externally, like Typesense Cloud, response times can be reduced by enabling compression, as the responses will be smaller. The JSON returned compresses very well.  
It reduces the data transmitted, possibly reducing hosting costs, at the expense of a little CPU time.

It is probably not recommended for locally hosted Typesense, as the CPU overhead for compressing and decompressing does not match the reduction in transfer time.  
Therefore the backward compatible default is false, to not interfere with existing code.

Regarding configuration of this, this is just my suggestion on how to do it.  
Feedback is welcome, just note that the existing config parameter is a `Action<Config>`