### PR TITLE
Support URL in ModelConfig

### DIFF
--- a/src/Typesense/AutoEmbeddingConfig.cs
+++ b/src/Typesense/AutoEmbeddingConfig.cs
@@ -26,6 +26,9 @@ public record ModelConfig
     [JsonPropertyName("api_key")]
     public string? ApiKey { get; init; }
 
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+
     [JsonPropertyName("access_token")]
     public string? AccessToken { get; init; }
 


### PR DESCRIPTION
When using an OpenAI-API-compatible API provider (like Azure) to generate embeddings, you need to be able to specify the URL of the service.

```

let schema = {
  "name": "products",
  "fields": [
    {
      "name": "product_name",
      "type": "string"
    },
    {
      "name": "embedding",
      "type": "float[]",
      "embed": {
        "from": [
          "product_name"
        ],
        "model_config": {
          "model_name": "openai/text-embedding-ada-002",
          "api_key": "your_api_key_as_required_by_the_custom_provider",
          "url": "https://your-custom-openai-compatible-api.domain.com"
        }
      }
    }
  ]
};

client.collections('products').create(schema);
```

This PR adds the URL property to the ModelConfig.