### PR TITLE
fixes the num_tokens_dropped deserialization

### DIFF
--- a/src/Typesense/SearchResult.cs
+++ b/src/Typesense/SearchResult.cs
@@ -92,7 +92,7 @@ public record TextMatchInfo
     public int FieldsMatched { get; set; }
 
     [JsonPropertyName("num_tokens_dropped")]
-    public int NumTokensDropped { get; set; }
+    public long NumTokensDropped { get; set; }
 
     [JsonPropertyName("score")]
     public string Score { get; set; }


### PR DESCRIPTION
Fixes the serialization issue described in #251 where the value of the dropped tokens does not fit into the int32 type.