### PR TITLE
Add Preset parameters to both search parameters classes

### DIFF
--- a/src/Typesense/SearchParameters.cs
+++ b/src/Typesense/SearchParameters.cs
@@ -101,7 +101,6 @@ public record SearchParameters
     [JsonPropertyName("preset")]
     public bool? Preset { get; set; }
     
-    
     /// <summary>
     /// Set this parameter to true if you wish to split the search query into space separated words yourself.
     /// When set to true, we will only split the search query by space,

--- a/src/Typesense/SearchParameters.cs
+++ b/src/Typesense/SearchParameters.cs
@@ -37,6 +37,13 @@ public record MultiSearchParameters : SearchParameters
     
     [JsonPropertyName("group_missing_values")]
     public bool? GroupMissingValues { get; set; }
+    
+    /// <summary>
+    /// Set this parameter to the value of a preset that has been created in typesense.
+    /// The query parameters of the preset will then be used in your search.
+    /// </summary>
+    [JsonPropertyName("preset")]
+    public bool? Preset { get; set; }
 
     public MultiSearchParameters(string collection, string text) : base(text)
     {
@@ -87,6 +94,14 @@ public record SearchParameters
     [JsonPropertyName("infix")]
     public string? Infix { get; set; }
 
+    /// <summary>
+    /// Set this parameter to the value of a preset that has been created in typesense.
+    /// The query parameters of the preset will then be used in your search.
+    /// </summary>
+    [JsonPropertyName("preset")]
+    public bool? Preset { get; set; }
+    
+    
     /// <summary>
     /// Set this parameter to true if you wish to split the search query into space separated words yourself.
     /// When set to true, we will only split the search query by space,


### PR DESCRIPTION
As per [Preset Documentation](https://typesense.org/docs/27.1/api/search.html#presets).
Adds the option to use preset search parameters, which can be very useful if you don't want to have to reference query parameters in your search calls.
Can't see any tests that need updating.. but if you  want any updated let me know