### PR TITLE
fix: Adjust typo of MaxCandidates property name in SearchParameters class

### DIFF
--- a/src/Typesense/SearchParameters.cs
+++ b/src/Typesense/SearchParameters.cs
@@ -353,7 +353,7 @@ public record SearchParameters
     /// Default: 4 (or 10000 if exhaustive_search is enabled).
     /// </summary>
     [JsonPropertyName("max_candidates")]
-    public int? MaxCandiates { get; set; }
+    public int? MaxCandidates { get; set; }
 
     /// <summary>
     /// Whether all variations of prefixes and typo corrections should be considered,


### PR DESCRIPTION
This pull request includes a small but important change to the `SearchParameters` class in the `src/Typesense/SearchParameters.cs` file. The change corrects a typo in the property name from `MaxCandiates` to `MaxCandidates`.

* [`src/Typesense/SearchParameters.cs`](diffhunk://#diff-444a98e9ba5f780c641dd4a40389b502639029d206677556ca25989ed8d024e0L356-R356): Corrected a typo in the `MaxCandidates` property name.