### PR TITLE
feat: Add additional MultiSearch methods to support up to 10 search p…

### DIFF
--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -178,7 +178,7 @@ public interface ITypesenseClient
     /// <param name="s1">First multi-search parameters.</param>
     /// <param name="s2">Second multi-search parameters.</param>
     /// <param name="s3">Third multi-search parameters.</param>
-    /// <param name="s4">Third multi-search parameters.</param>
+    /// <param name="s4">Fourth multi-search parameters.</param>
     /// <param name="ctk">The optional cancellation token.</param>
     /// <returns>The search results.</returns>
     /// <exception cref="InvalidOperationException"></exception>
@@ -188,6 +188,106 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
     Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>)> MultiSearch<T1, T2, T3, T4>
         (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, CancellationToken ctk = default);
+
+    /// <summary>
+    /// Multiple Searches for documents in the specified collections using the supplied search parameters.
+    /// </summary>
+    /// <param name="s1">First multi-search parameters.</param>
+    /// <param name="s2">Second multi-search parameters.</param>
+    /// <param name="s3">Third multi-search parameters.</param>
+    /// <param name="s4">Fourth multi-search parameters.</param>
+    /// <param name="s5">Fifth multi-search parameters.</param>
+    /// <param name="ctk">The optional cancellation token.</param>
+    /// <returns>The search results.</returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="TypesenseApiException"></exception>
+    /// <exception cref="TypesenseApiBadRequestException"></exception>
+    /// <exception cref="TypesenseApiNotFoundException"></exception>
+    /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
+    Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>)> MultiSearch<T1, T2, T3, T4, T5>
+        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, CancellationToken ctk = default);
+
+    /// <summary>
+    /// Multiple Searches for documents in the specified collections using the supplied search parameters.
+    /// </summary>
+    /// <param name="s1">First multi-search parameters.</param>
+    /// <param name="s2">Second multi-search parameters.</param>
+    /// <param name="s3">Third multi-search parameters.</param>
+    /// <param name="s4">Fourth multi-search parameters.</param>
+    /// <param name="s5">Fifth multi-search parameters.</param>
+    /// <param name="s6">Sixth multi-search parameters.</param>
+    /// <param name="ctk">The optional cancellation token.</param>
+    /// <returns>The search results.</returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="TypesenseApiException"></exception>
+    /// <exception cref="TypesenseApiBadRequestException"></exception>
+    /// <exception cref="TypesenseApiNotFoundException"></exception>
+    /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
+    Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>)> MultiSearch<T1, T2, T3, T4, T5, T6>
+        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, MultiSearchParameters s6, CancellationToken ctk = default);
+
+    /// <summary>
+    /// Multiple Searches for documents in the specified collections using the supplied search parameters.
+    /// </summary>
+    /// <param name="s1">First multi-search parameters.</param>
+    /// <param name="s2">Second multi-search parameters.</param>
+    /// <param name="s3">Third multi-search parameters.</param>
+    /// <param name="s4">Fourth multi-search parameters.</param>
+    /// <param name="s5">Fifth multi-search parameters.</param>
+    /// <param name="s6">Sixth multi-search parameters.</param>
+    /// <param name="s7">Seventh multi-search parameters.</param>
+    /// <param name="ctk">The optional cancellation token.</param>
+    /// <returns>The search results.</returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="TypesenseApiException"></exception>
+    /// <exception cref="TypesenseApiBadRequestException"></exception>
+    /// <exception cref="TypesenseApiNotFoundException"></exception>
+    /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
+    Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>, MultiSearchResult<T7>)> MultiSearch<T1, T2, T3, T4, T5, T6, T7>
+        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, MultiSearchParameters s6, MultiSearchParameters s7, CancellationToken ctk = default);
+
+    /// <summary>
+    /// Multiple Searches for documents in the specified collections using the supplied search parameters.
+    /// </summary>
+    /// <param name="s1">First multi-search parameters.</param>
+    /// <param name="s2">Second multi-search parameters.</param>
+    /// <param name="s3">Third multi-search parameters.</param>
+    /// <param name="s4">Fourth multi-search parameters.</param>
+    /// <param name="s5">Fifth multi-search parameters.</param>
+    /// <param name="s6">Sixth multi-search parameters.</param>
+    /// <param name="s7">Seventh multi-search parameters.</param>
+    /// <param name="s8">Eighth multi-search parameters.</param>
+    /// <param name="ctk">The optional cancellation token.</param>
+    /// <returns>The search results.</returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="TypesenseApiException"></exception>
+    /// <exception cref="TypesenseApiBadRequestException"></exception>
+    /// <exception cref="TypesenseApiNotFoundException"></exception>
+    /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
+    Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>, MultiSearchResult<T7>, MultiSearchResult<T8>)> MultiSearch<T1, T2, T3, T4, T5, T6, T7, T8>
+        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, MultiSearchParameters s6, MultiSearchParameters s7, MultiSearchParameters s8, CancellationToken ctk = default);
+
+    /// <summary>
+    /// Multiple Searches for documents in the specified collections using the supplied search parameters.
+    /// </summary>
+    /// <param name="s1">First multi-search parameters.</param>
+    /// <param name="s2">Second multi-search parameters.</param>
+    /// <param name="s3">Third multi-search parameters.</param>
+    /// <param name="s4">Fourth multi-search parameters.</param>
+    /// <param name="s5">Fifth multi-search parameters.</param>
+    /// <param name="s6">Sixth multi-search parameters.</param>
+    /// <param name="s7">Seventh multi-search parameters.</param>
+    /// <param name="s8">Eighth multi-search parameters.</param>
+    /// <param name="s9">Ninth multi-search parameters.</param>
+    /// <param name="ctk">The optional cancellation token.</param>
+    /// <returns>The search results.</returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="TypesenseApiException"></exception>
+    /// <exception cref="TypesenseApiBadRequestException"></exception>
+    /// <exception cref="TypesenseApiNotFoundException"></exception>
+    /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
+    Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>, MultiSearchResult<T7>, MultiSearchResult<T8>, MultiSearchResult<T9>)> MultiSearch<T1, T2, T3, T4, T5, T6, T7, T8, T9>
+        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, MultiSearchParameters s6, MultiSearchParameters s7, MultiSearchParameters s8, MultiSearchParameters s9, CancellationToken ctk = default);
 
     /// <summary>
     /// Gets the document in the specified collection on id.

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -214,6 +214,131 @@ public class TypesenseClient : ITypesenseClient
             : throw new InvalidOperationException("Could not get results from multi-search result.");
     }
 
+    public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>)> MultiSearch<T1, T2, T3, T4, T5>(
+        MultiSearchParameters s1,
+        MultiSearchParameters s2,
+        MultiSearchParameters s3,
+        MultiSearchParameters s4,
+        MultiSearchParameters s5,
+        CancellationToken ctk = default)
+    {
+        var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5 } };
+        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+
+        return response.TryGetProperty("results", out var results)
+            ? (HandleDeserializeMultiSearch<T1>(results[0]),
+               HandleDeserializeMultiSearch<T2>(results[1]),
+               HandleDeserializeMultiSearch<T3>(results[2]),
+               HandleDeserializeMultiSearch<T4>(results[3]),
+               HandleDeserializeMultiSearch<T5>(results[4]))
+            : throw new InvalidOperationException("Could not get results from multi-search result.");
+    }
+
+    public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>)> MultiSearch<T1, T2, T3, T4, T5, T6>(
+        MultiSearchParameters s1,
+        MultiSearchParameters s2,
+        MultiSearchParameters s3,
+        MultiSearchParameters s4,
+        MultiSearchParameters s5,
+        MultiSearchParameters s6,
+        CancellationToken ctk = default)
+    {
+        var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5, s6 } };
+        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+
+        return response.TryGetProperty("results", out var results)
+            ? (HandleDeserializeMultiSearch<T1>(results[0]),
+               HandleDeserializeMultiSearch<T2>(results[1]),
+               HandleDeserializeMultiSearch<T3>(results[2]),
+               HandleDeserializeMultiSearch<T4>(results[3]),
+               HandleDeserializeMultiSearch<T5>(results[4]),
+               HandleDeserializeMultiSearch<T6>(results[5]))
+            : throw new InvalidOperationException("Could not get results from multi-search result.");
+    }
+
+    public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>, MultiSearchResult<T7>)> MultiSearch<T1, T2, T3, T4, T5, T6, T7>(
+        MultiSearchParameters s1,
+        MultiSearchParameters s2,
+        MultiSearchParameters s3,
+        MultiSearchParameters s4,
+        MultiSearchParameters s5,
+        MultiSearchParameters s6,
+        MultiSearchParameters s7,
+        CancellationToken ctk = default)
+    {
+        var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5, s6, s7 } };
+        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+
+        return response.TryGetProperty("results", out var results)
+            ? (HandleDeserializeMultiSearch<T1>(results[0]),
+               HandleDeserializeMultiSearch<T2>(results[1]),
+               HandleDeserializeMultiSearch<T3>(results[2]),
+               HandleDeserializeMultiSearch<T4>(results[3]),
+               HandleDeserializeMultiSearch<T5>(results[4]),
+               HandleDeserializeMultiSearch<T6>(results[5]),
+               HandleDeserializeMultiSearch<T7>(results[6]))
+            : throw new InvalidOperationException("Could not get results from multi-search result.");
+    }
+
+    public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>, MultiSearchResult<T7>, MultiSearchResult<T8>)> MultiSearch<T1, T2, T3, T4, T5, T6, T7, T8>(
+        MultiSearchParameters s1,
+        MultiSearchParameters s2,
+        MultiSearchParameters s3,
+        MultiSearchParameters s4,
+        MultiSearchParameters s5,
+        MultiSearchParameters s6,
+        MultiSearchParameters s7,
+        MultiSearchParameters s8,
+        CancellationToken ctk = default)
+    {
+        var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5, s6, s7, s8 } };
+        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+
+        return response.TryGetProperty("results", out var results)
+            ? (HandleDeserializeMultiSearch<T1>(results[0]),
+               HandleDeserializeMultiSearch<T2>(results[1]),
+               HandleDeserializeMultiSearch<T3>(results[2]),
+               HandleDeserializeMultiSearch<T4>(results[3]),
+               HandleDeserializeMultiSearch<T5>(results[4]),
+               HandleDeserializeMultiSearch<T6>(results[5]),
+               HandleDeserializeMultiSearch<T7>(results[6]),
+               HandleDeserializeMultiSearch<T8>(results[7]))
+            : throw new InvalidOperationException("Could not get results from multi-search result.");
+    }
+
+    public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>, MultiSearchResult<T7>, MultiSearchResult<T8>, MultiSearchResult<T9>)> MultiSearch<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+        MultiSearchParameters s1,
+        MultiSearchParameters s2,
+        MultiSearchParameters s3,
+        MultiSearchParameters s4,
+        MultiSearchParameters s5,
+        MultiSearchParameters s6,
+        MultiSearchParameters s7,
+        MultiSearchParameters s8,
+        MultiSearchParameters s9,
+        CancellationToken ctk = default)
+    {
+        var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5, s6, s7, s8, s9 } };
+        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+
+        return response.TryGetProperty("results", out var results)
+            ? (HandleDeserializeMultiSearch<T1>(results[0]),
+               HandleDeserializeMultiSearch<T2>(results[1]),
+               HandleDeserializeMultiSearch<T3>(results[2]),
+               HandleDeserializeMultiSearch<T4>(results[3]),
+               HandleDeserializeMultiSearch<T5>(results[4]),
+               HandleDeserializeMultiSearch<T6>(results[5]),
+               HandleDeserializeMultiSearch<T7>(results[6]),
+               HandleDeserializeMultiSearch<T8>(results[7]),
+               HandleDeserializeMultiSearch<T9>(results[8]))
+            : throw new InvalidOperationException("Could not get results from multi-search result.");
+    }
+
     public Task<T> RetrieveDocument<T>(string collection, string id, CancellationToken ctk = default) where T : class
     {
         if (string.IsNullOrWhiteSpace(collection))

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -1392,6 +1392,59 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         }
     }
 
+    [Fact, TestPriority(11)]
+    public async Task Multi_search_query_nine()
+    {
+        var expected = new Company
+        {
+            Id = "124",
+            CompanyName = "Stark Industries",
+            NumEmployees = 6000,
+            Location = new Location
+            {
+                City = "Phoenix",
+                Country = "USA"
+            },
+        };
+
+        var query = new MultiSearchParameters("companies", "Stark", "company_name");
+
+        // We just use the same for queries for simplicity.
+        // We mainly care about multiple queries being returned with the correct types of <T>.
+        var (r1, r2, r3, r4, r5, r6, r7, r8, r9) = await _client.MultiSearch<Company, Company, Company, Company, Company, Company, Company, Company, Company>(
+            query, query, query, query, query, query, query, query, query);
+
+        using (var scope = new AssertionScope())
+        {
+            r1.Found.Should().Be(1);
+            r1.Hits.First().Document.Should().BeEquivalentTo(expected);
+
+            r2.Found.Should().Be(1);
+            r2.Hits.First().Document.Should().BeEquivalentTo(expected);
+
+            r3.Found.Should().Be(1);
+            r3.Hits.First().Document.Should().BeEquivalentTo(expected);
+
+            r4.Found.Should().Be(1);
+            r4.Hits.First().Document.Should().BeEquivalentTo(expected);
+
+            r5.Found.Should().Be(1);
+            r5.Hits.First().Document.Should().BeEquivalentTo(expected);
+
+            r6.Found.Should().Be(1);
+            r6.Hits.First().Document.Should().BeEquivalentTo(expected);
+
+            r7.Found.Should().Be(1);
+            r7.Hits.First().Document.Should().BeEquivalentTo(expected);
+
+            r8.Found.Should().Be(1);
+            r8.Hits.First().Document.Should().BeEquivalentTo(expected);
+
+            r9.Found.Should().Be(1);
+            r9.Hits.First().Document.Should().BeEquivalentTo(expected);
+        }
+    }
+
     [Fact, TestPriority(12)]
     public async Task Delete_document_by_id()
     {


### PR DESCRIPTION
This pull request focuses on expanding the multi-search capabilities by adding support for additional search parameters.

### Enhancements to Multi-Search Capabilities:

* Updated the parameter documentation for the existing `MultiSearch` method to correctly describe the fourth parameter as "Fourth multi-search parameters" (`src/Typesense/ITypesenseClient.cs`).
* Added new `MultiSearch` methods to support up to nine search parameters, including corresponding XML documentation for each method (`src/Typesense/ITypesenseClient.cs`).
* Implemented the new `MultiSearch` methods in the `TypesenseClient` class to handle up to nine search parameters