### PR TITLE
Support collection metadata and async references

### DIFF
--- a/src/Typesense/CollectionResponse.cs
+++ b/src/Typesense/CollectionResponse.cs
@@ -28,6 +28,9 @@ public record CollectionResponse
     [JsonPropertyName("enable_nested_fields")]
     public bool EnableNestedFields { get; init; }
 
+    [JsonPropertyName("metadata")]
+    public IDictionary<string, object>? Metadata { get; init; }
+
     [JsonPropertyName("created_at"), JsonConverter(typeof(UnixEpochDateTimeConverter))]
     public DateTime CreatedAt { get; init; }
 
@@ -39,7 +42,8 @@ public record CollectionResponse
         string defaultSortingField,
         IReadOnlyCollection<string> tokenSeparators,
         IReadOnlyCollection<string> symbolsToIndex,
-        bool enableNestedFields)
+        bool enableNestedFields,
+        IDictionary<string, object>? metadata = null)
     {
         Name = name;
         NumberOfDocuments = numberOfDocuments;
@@ -48,5 +52,6 @@ public record CollectionResponse
         TokenSeparators = tokenSeparators;
         SymbolsToIndex = symbolsToIndex;
         EnableNestedFields = enableNestedFields;
+        Metadata = metadata;
     }
 }

--- a/src/Typesense/CollectionResponse.cs
+++ b/src/Typesense/CollectionResponse.cs
@@ -29,7 +29,7 @@ public record CollectionResponse
     public bool EnableNestedFields { get; init; }
 
     [JsonPropertyName("metadata")]
-    public IDictionary<string, object>? Metadata { get; init; }
+    public IDictionary<string, object?>? Metadata { get; init; }
 
     [JsonPropertyName("created_at"), JsonConverter(typeof(UnixEpochDateTimeConverter))]
     public DateTime CreatedAt { get; init; }

--- a/src/Typesense/Field.cs
+++ b/src/Typesense/Field.cs
@@ -42,6 +42,9 @@ public record Field
     [JsonPropertyName("reference")]
     public string? Reference { get; init; }
 
+    [JsonPropertyName("async_reference")]
+    public bool? AsyncReference { get; init; }
+
     [JsonPropertyName("stem")]
     public bool? Stem { get; init; }
 

--- a/src/Typesense/Schema.cs
+++ b/src/Typesense/Schema.cs
@@ -25,7 +25,7 @@ public record Schema
     public bool? EnableNestedFields { get; init; }
 
     [JsonPropertyName("metadata")]
-    public IDictionary<string, object>? Metadata { get; init; }
+    public IDictionary<string, object?>? Metadata { get; init; }
 
     [Obsolete("Use multi-arity constructor instead.")]
     public Schema()

--- a/src/Typesense/Schema.cs
+++ b/src/Typesense/Schema.cs
@@ -24,6 +24,9 @@ public record Schema
     [JsonPropertyName("enable_nested_fields")]
     public bool? EnableNestedFields { get; init; }
 
+    [JsonPropertyName("metadata")]
+    public IDictionary<string, object>? Metadata { get; init; }
+
     [Obsolete("Use multi-arity constructor instead.")]
     public Schema()
     {

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -319,6 +319,94 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         await _client.DeleteCollection(collectionName);
     }
 
+    // We test metadata individually,
+    // because we don't want to impact tests that depend on shared collection/schema.
+    [Fact, TestPriority(1)]
+    public async Task Create_schema_with_metadata_and_reference()
+    {
+        const string collectionName = "collection-with-metadata";
+
+        var expected = new CollectionResponse(
+            collectionName,
+            0,
+            new List<Field>
+            {
+                new Field(
+                    name: "name",
+                    type: FieldType.String,
+                    facet: false,
+                    optional: false,
+                    index: true,
+                    sort: false,
+                    infix: false,
+                    locale: "")
+                {
+                    Stem = false,
+                    Store = true
+                },
+                new Field(
+                    name: "company_name",
+                    type: FieldType.String,
+                    facet: false,
+                    optional: false,
+                    index: true,
+                    sort: false,
+                    infix: false,
+                    locale: "")
+                {
+                    Stem = false,
+                    Store = true,
+                    Reference = "companies.company_name",
+                    AsyncReference = true
+                },
+            },
+            "",
+            new List<string>(),
+            new List<string>(),
+            false,
+            new Dictionary<string, object>
+            {
+                ["version"] = JsonSerializer.SerializeToElement(1.2f)
+            });
+
+        var schema = new Schema(
+            collectionName,
+            new List<Field>
+            {
+                new Field(
+                    "name",
+                    FieldType.String),
+                new Field(
+                    "company_name",
+                    FieldType.String)
+                {
+                    Reference = "companies.company_name",
+                    AsyncReference = true
+                }
+            })
+        {
+            Metadata = new Dictionary<string, object>
+            {
+                ["version"] = 1.2f
+            }
+        };
+
+        var response = await _client.CreateCollection(schema);
+
+        // CreatedAt cannot be deterministic
+        response.CreatedAt.Should().NotBe(default);
+        expected = expected with { CreatedAt = response.CreatedAt };
+
+        response.Should().BeEquivalentTo(expected, options => options.Excluding(response => response.Metadata));
+
+        // FluentAssertions doesn't support JsonElements, so we need to check it separately.
+        response.Metadata.Should().NotBeEmpty();
+        response.Metadata["version"].As<JsonElement>().GetSingle().Should().Be(1.2f);
+
+        // Cleanup
+        await _client.DeleteCollection(collectionName);
+    }
+
     [Fact, TestPriority(1)]
     public async Task Retrieve_collection()
     {

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -366,7 +366,8 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             false,
             new Dictionary<string, object>
             {
-                ["version"] = JsonSerializer.SerializeToElement(1.2f)
+                ["version"] = JsonSerializer.SerializeToElement(1.2f),
+                ["null"] = null
             });
 
         var schema = new Schema(
@@ -387,7 +388,8 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         {
             Metadata = new Dictionary<string, object>
             {
-                ["version"] = 1.2f
+                ["version"] = 1.2f,
+                ["null"] = null
             }
         };
 
@@ -2045,7 +2047,8 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                             0.19744956493377686,
                             null));
             }
-        } finally
+        }
+        finally
         {
             // Make sure that no matter what the collection is deleted.
             try
@@ -2188,7 +2191,8 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                             0.4871443510055542,
                             null));
             }
-        } finally
+        }
+        finally
         {
             // Make sure that no matter what the collection is deleted.
             try


### PR DESCRIPTION
- Allow collections to contain [metadata](https://typesense.org/docs/28.0/api/collections.html#adding-metadata-to-schema).
- Support [async references](https://typesense.org/docs/28.0/api/joins.html#asynchronous-references)