### PR TITLE
feat: Add stream-based document import with unit tests

### DIFF
--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -529,6 +530,36 @@ public interface ITypesenseClient
     Task<List<ImportResponse>> ImportDocuments<T>(
         string collection,
         IEnumerable<T> documents,
+        int batchSize = 40,
+        ImportType importType = ImportType.Create,
+        int? remoteEmbeddingBatchSize = null,
+        bool? returnId = null);
+
+    /// <summary>
+    /// Batch import documents.
+    /// </summary>
+    /// <param name="collection">The collection name.</param>
+    /// <param name="stream">A stream of the documents to be imported.</param>
+    /// <param name="batchSize">The number of documents that should be imported - defaults to 40.</param>
+    /// <param name="importType">The import type, can either be Create, Update or Upsert - defaults to Create.</param>
+    /// <param name="remoteEmbeddingBatchSize">
+    /// Max size of each batch that will be sent to remote APIs while importing multiple documents at once.
+    /// Using lower amount will lower timeout risk, but increase number of requests made.
+    /// If not specified, typesense server will default to 200.
+    /// </param>
+    /// <param name="returnId">Eanble to return the id fo the document in the response.</param>
+    /// <returns>A collection of import responses.</returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="TypesenseApiException"></exception>
+    /// <exception cref="TypesenseApiBadRequestException"></exception>
+    /// <exception cref="TypesenseApiNotFoundException"></exception>
+    /// <exception cref="TypesenseApiConflictException"></exception>
+    /// <exception cref="TypesenseApiUnprocessableEntityException"></exception>
+    /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
+    Task<List<ImportResponse>> ImportDocuments(
+        string collection,
+        Stream stream,
         int batchSize = 40,
         ImportType importType = ImportType.Create,
         int? remoteEmbeddingBatchSize = null,

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -538,6 +538,20 @@ public class TypesenseClient : ITypesenseClient
         return await ImportDocuments(collection, streamJsonLinesContent, batchSize, importType, remoteEmbeddingBatchSize).ConfigureAwait(false);
     }
 
+    public async Task<List<ImportResponse>> ImportDocuments(
+        string collection,
+        Stream stream,
+        int batchSize = 40,
+        ImportType importType = ImportType.Create,
+        int? remoteEmbeddingBatchSize = null,
+        bool? returnId = null)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        using var streamContent = new StreamContent(stream);
+        return await ImportDocuments(collection, streamContent, batchSize, importType, remoteEmbeddingBatchSize).ConfigureAwait(false);
+    }
+
     public Task<List<T>> ExportDocuments<T>(string collection, CancellationToken ctk = default)
     {
         return ExportDocuments<T>(collection, new ExportParameters(), ctk);

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -819,6 +819,44 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         {
             await _client.DeleteDocument<Company>("companies", documentId);
         }
+    }
+
+    [Fact, TestPriority(7)]
+    public async Task Import_documents_create_stream()
+    {
+        var expected = new List<ImportResponse>
+        {
+            new ImportResponse(true),
+            new ImportResponse(true),
+        };
+
+        var companies = new List<Company>
+        {
+            new Company
+            {
+                Id = "125",
+                CompanyName = "Future Technology",
+                NumEmployees = 1232,
+                Location = new Location
+                {
+                    City = "Aarhus",
+                    Country = "DK"
+                },
+            },
+            new Company
+            {
+                Id = "126",
+                CompanyName = "Random Corp.",
+                NumEmployees = 531,
+                Location = new Location
+                {
+                    City = "Copenhagen",
+                    Country = "DK"
+                },
+            }
+        };
+
+        var companyLines = JsonLines(companies).ToList();
 
         using var memoryStream = new MemoryStream();
         await using (var writer = new StreamWriter(memoryStream))
@@ -830,9 +868,10 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             await writer.FlushAsync();
             memoryStream.Position = 0;
 
-            response = await _client.ImportDocuments("companies", memoryStream, 40, ImportType.Create);
+            var response = await _client.ImportDocuments("companies", memoryStream, 40, ImportType.Create);
+            response.Should().BeEquivalentTo(expected);
         }
-        response.Should().BeEquivalentTo(expected);
+
         foreach (var documentId in companies.Select(c => c.Id))
         {
             await _client.DeleteDocument<Company>("companies", documentId);
@@ -884,6 +923,44 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
 
         response = await _client.ImportDocuments("companies", string.Join('\n', companyLines), 40, ImportType.Update);
         response.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact, TestPriority(7)]
+    public async Task Import_documents_update_stream()
+    {
+        var expected = new List<ImportResponse>
+        {
+            new ImportResponse(true),
+            new ImportResponse(true),
+        };
+
+        var companies = new List<Company>
+        {
+            new Company
+            {
+                Id = "125",
+                CompanyName = "Future Technology",
+                NumEmployees = 1233,
+                Location = new Location
+                {
+                    City = "Aarhus",
+                    Country = "DK"
+                },
+            },
+            new Company
+            {
+                Id = "126",
+                CompanyName = "Random Corp.",
+                NumEmployees = 532,
+                Location = new Location
+                {
+                    City = "Copenhagen",
+                    Country = "DK"
+                },
+            }
+        };
+
+        var companyLines = JsonLines(companies).ToList();
 
         using var memoryStream = new MemoryStream();
         await using (var writer = new StreamWriter(memoryStream))
@@ -895,9 +972,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             await writer.FlushAsync();
             memoryStream.Position = 0;
 
-            response = await _client.ImportDocuments("companies", memoryStream, 40, ImportType.Update);
+            var response = await _client.ImportDocuments("companies", memoryStream, 40, ImportType.Update);
+            response.Should().BeEquivalentTo(expected);
         }
-        response.Should().BeEquivalentTo(expected);
     }
 
     [Fact, TestPriority(7)]
@@ -946,6 +1023,44 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
 
         response = await _client.ImportDocuments("companies", string.Join('\n', companyLines), 40, ImportType.Upsert);
         response.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact, TestPriority(7)]
+    public async Task Import_documents_upsert_stream()
+    {
+        var expected = new List<ImportResponse>
+        {
+            new ImportResponse(true),
+            new ImportResponse(true),
+        };
+
+        var companies = new List<Company>
+        {
+            new Company
+            {
+                Id = "125",
+                CompanyName = "Future Technology",
+                NumEmployees = 1232,
+                Location = new Location
+                {
+                    City = "Aarhus",
+                    Country = "DK"
+                },
+            },
+            new Company
+            {
+                Id = "126",
+                CompanyName = "Random Corp.",
+                NumEmployees = 531,
+                Location = new Location
+                {
+                    City = "Copenhagen",
+                    Country = "DK"
+                },
+            }
+        };
+
+        var companyLines = JsonLines(companies).ToList();
 
         using var memoryStream = new MemoryStream();
         await using (var writer = new StreamWriter(memoryStream))
@@ -957,9 +1072,9 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             await writer.FlushAsync();
             memoryStream.Position = 0;
 
-            response = await _client.ImportDocuments("companies", memoryStream, 40, ImportType.Upsert);
+            var response = await _client.ImportDocuments("companies", memoryStream, 40, ImportType.Upsert);
+            response.Should().BeEquivalentTo(expected);
         }
-        response.Should().BeEquivalentTo(expected);
     }
 
     [Fact, TestPriority(7)]
@@ -1008,6 +1123,44 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
 
         response = await _client.ImportDocuments("companies", string.Join('\n', companyLines), 40, ImportType.Emplace);
         response.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact, TestPriority(7)]
+    public async Task Import_documents_emplace_stream()
+    {
+        var expected = new List<ImportResponse>
+        {
+            new ImportResponse(true),
+            new ImportResponse(true),
+        };
+
+        var companies = new List<Company>
+        {
+            new Company
+            {
+                Id = "125",
+                CompanyName = "Future Technology",
+                NumEmployees = 1232,
+                Location = new Location
+                {
+                    City = "Aarhus",
+                    Country = "DK"
+                },
+            },
+            new Company
+            {
+                Id = "126",
+                CompanyName = "Random Corp.",
+                NumEmployees = 531,
+                Location = new Location
+                {
+                    City = "Copenhagen",
+                    Country = "DK"
+                },
+            }
+        };
+
+        var companyLines = JsonLines(companies).ToList();
 
         using var memoryStream = new MemoryStream();
         await using (var writer = new StreamWriter(memoryStream))
@@ -1019,10 +1172,11 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             await writer.FlushAsync();
             memoryStream.Position = 0;
 
-            response = await _client.ImportDocuments("companies", memoryStream, 40, ImportType.Emplace);
+            var response = await _client.ImportDocuments("companies", memoryStream, 40, ImportType.Emplace);
+            response.Should().BeEquivalentTo(expected);
         }
-        response.Should().BeEquivalentTo(expected);
     }
+
     private static readonly JsonSerializerOptions JsonOptionsCamelCaseIgnoreWritingNull = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -814,6 +815,28 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         }
         response = await _client.ImportDocuments("companies", string.Join('\n', companyLines), 40, ImportType.Create);
         response.Should().BeEquivalentTo(expected);
+        foreach (var documentId in companies.Select(c => c.Id))
+        {
+            await _client.DeleteDocument<Company>("companies", documentId);
+        }
+
+        using var memoryStream = new MemoryStream();
+        await using (var writer = new StreamWriter(memoryStream))
+        {
+            foreach (var line in companyLines)
+            {
+                await writer.WriteLineAsync(line);
+            }
+            await writer.FlushAsync();
+            memoryStream.Position = 0;
+
+            response = await _client.ImportDocuments("companies", memoryStream, 40, ImportType.Create);
+        }
+        response.Should().BeEquivalentTo(expected);
+        foreach (var documentId in companies.Select(c => c.Id))
+        {
+            await _client.DeleteDocument<Company>("companies", documentId);
+        }
     }
 
     [Fact, TestPriority(7)]
@@ -860,6 +883,20 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         response.Should().BeEquivalentTo(expected);
 
         response = await _client.ImportDocuments("companies", string.Join('\n', companyLines), 40, ImportType.Update);
+        response.Should().BeEquivalentTo(expected);
+
+        using var memoryStream = new MemoryStream();
+        await using (var writer = new StreamWriter(memoryStream))
+        {
+            foreach (var line in companyLines)
+            {
+                await writer.WriteLineAsync(line);
+            }
+            await writer.FlushAsync();
+            memoryStream.Position = 0;
+
+            response = await _client.ImportDocuments("companies", memoryStream, 40, ImportType.Update);
+        }
         response.Should().BeEquivalentTo(expected);
     }
 
@@ -909,6 +946,20 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
 
         response = await _client.ImportDocuments("companies", string.Join('\n', companyLines), 40, ImportType.Upsert);
         response.Should().BeEquivalentTo(expected);
+
+        using var memoryStream = new MemoryStream();
+        await using (var writer = new StreamWriter(memoryStream))
+        {
+            foreach (var line in companyLines)
+            {
+                await writer.WriteLineAsync(line);
+            }
+            await writer.FlushAsync();
+            memoryStream.Position = 0;
+
+            response = await _client.ImportDocuments("companies", memoryStream, 40, ImportType.Upsert);
+        }
+        response.Should().BeEquivalentTo(expected);
     }
 
     [Fact, TestPriority(7)]
@@ -956,6 +1007,20 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         response.Should().BeEquivalentTo(expected);
 
         response = await _client.ImportDocuments("companies", string.Join('\n', companyLines), 40, ImportType.Emplace);
+        response.Should().BeEquivalentTo(expected);
+
+        using var memoryStream = new MemoryStream();
+        await using (var writer = new StreamWriter(memoryStream))
+        {
+            foreach (var line in companyLines)
+            {
+                await writer.WriteLineAsync(line);
+            }
+            await writer.FlushAsync();
+            memoryStream.Position = 0;
+
+            response = await _client.ImportDocuments("companies", memoryStream, 40, ImportType.Emplace);
+        }
         response.Should().BeEquivalentTo(expected);
     }
     private static readonly JsonSerializerOptions JsonOptionsCamelCaseIgnoreWritingNull = new()


### PR DESCRIPTION
I added support for Import via a streaming jsonl file to the other supported Import patterns.

This API can be found here: https://typesense.org/docs/28.0/api/documents.html#import-a-jsonl-file