### PR TITLE
Fix nullable datetimes for searchoverrides

### DIFF
--- a/src/Typesense/Converter/UnixEpochDateTimeLongConverter.cs
+++ b/src/Typesense/Converter/UnixEpochDateTimeLongConverter.cs
@@ -7,16 +7,26 @@ namespace Typesense.Converter;
 /// <summary>
 /// Converts between nullable DateTime and Unix epoch seconds as a long integer value.
 /// </summary>
-public class UnixEpochDateTimeLongConverter : JsonConverter<DateTime>
+public class UnixEpochDateTimeLongConverter : JsonConverter<DateTime?>
 {
-    public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
+        if (reader.TokenType == JsonTokenType.Null)
+            return null;
+        
         return DateTime.UnixEpoch.AddSeconds(reader.GetInt64());
     }
 
-    public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+    public override void Write(Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options)
     {
         ArgumentNullException.ThrowIfNull(writer);
-        writer.WriteNumberValue(Convert.ToInt64((value - DateTime.UnixEpoch).TotalSeconds));
+        
+        if (value == null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+        
+        writer.WriteNumberValue(Convert.ToInt64((value.Value - DateTime.UnixEpoch).TotalSeconds));
     }
 }

--- a/src/Typesense/SearchOverrideResponse.cs
+++ b/src/Typesense/SearchOverrideResponse.cs
@@ -38,10 +38,10 @@ public record SearchOverrideResponse
     public bool StopProcessing { get; init; }
 
     [JsonPropertyName("effective_from_ts"), JsonConverter(typeof(UnixEpochDateTimeLongConverter))]
-    public DateTime EffectiveFromTs { get; init; }
+    public DateTime? EffectiveFromTs { get; init; }
 
     [JsonPropertyName("effective_to_ts"), JsonConverter(typeof(UnixEpochDateTimeLongConverter))]
-    public DateTime EffectiveToTs { get; init; }
+    public DateTime? EffectiveToTs { get; init; }
 
     [JsonPropertyName("rule")]
     public Rule Rule { get; init; }
@@ -49,7 +49,7 @@ public record SearchOverrideResponse
     [JsonConstructor]
     public SearchOverrideResponse(IEnumerable<Exclude> excludes, IEnumerable<Include> includes,
         IDictionary<string, object> metadata, string filterBy, string sortBy, string replaceQuery, bool removeMatchedTokens,
-        bool filterCuratedHits, bool stopProcessing, DateTime effectiveFromTs, DateTime effectiveToTs,
+        bool filterCuratedHits, bool stopProcessing, DateTime? effectiveFromTs, DateTime? effectiveToTs,
         Rule rule, string id)
     {
         Excludes = excludes;

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -2032,6 +2032,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                     first.EffectiveFromTs.Should().HaveYear(DateTime.UtcNow.Year);
                     first.EffectiveFromTs.Should().HaveMonth(DateTime.UtcNow.Month);
                     first.EffectiveFromTs.Should().HaveDay(DateTime.UtcNow.Day);
+                    first.EffectiveToTs.Should().BeNull();
                     first.Rule.Should().BeEquivalentTo(expected.Rule);
                 });
 


### PR DESCRIPTION
We saw issues with null values that were interpret as DateTime.MinValue