### PR TITLE
Feat/additional path for client

### DIFF
--- a/src/Typesense/Setup/Node.cs
+++ b/src/Typesense/Setup/Node.cs
@@ -18,6 +18,10 @@ public record Node
     /// Protocol for the Typesense service - defaults to http.
     /// </summary>
     public string Protocol { get; set; } = "http";
+    /// <summary>
+    /// Protocol for the Typesense service - defaults to http.
+    /// </summary>
+    public string AdditionalPath { get; set; } = "";
 
     [Obsolete("Use multi-arity constructor instead.")]
     public Node()
@@ -51,5 +55,33 @@ public record Node
         Host = host;
         Port = port;
         Protocol = protocol;
+    }
+
+    /// <param name="host">Hostname for the Typesense service.</param>
+    /// <param name="port">Port for the typesense service.</param>
+    /// <param name="protocol">Protocol for the Typesense service - defaults to http.</param>
+    /// <param name="additionalPath">additionalPath for the Typesense service - defaults to empty string.</param>
+    /// <exception cref="ArgumentException"></exception>
+    public Node(string host, string port, string protocol = "http", string additionalPath = "")
+    {
+        if (string.IsNullOrEmpty(host))
+        {
+            throw new ArgumentException("Cannot be NULL or empty.", nameof(host));
+        }
+
+        if (string.IsNullOrEmpty(protocol))
+        {
+            throw new ArgumentException("Cannot be NULL or empty.", nameof(protocol));
+        }
+
+        if (string.IsNullOrEmpty(port))
+        {
+            throw new ArgumentException("Cannot be NULL or empty.", nameof(port));
+        }
+
+        Host = host;
+        Port = port;
+        Protocol = protocol;
+        AdditionalPath = additionalPath;
     }
 }

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -832,7 +832,7 @@ public class TypesenseClient : ITypesenseClient
 
     private async Task<T> Delete<T>(string path, JsonSerializerOptions? jsonSerializerOptions, CancellationToken ctk = default)
     {
-        using var response = await _httpClient.DeleteAsync(path, ctk).ConfigureAwait(false);
+        using var response = await _httpClient.DeleteAsync(path.TrimStart('/'), ctk).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
             await GetException(response, ctk).ConfigureAwait(false);
 
@@ -841,7 +841,7 @@ public class TypesenseClient : ITypesenseClient
 
     private async Task<T> Post<T>(string path, HttpContent? httpContent, JsonSerializerOptions? jsonSerializerOptions, CancellationToken ctk = default)
     {
-        using var response = await _httpClient.PostAsync(path, httpContent, ctk).ConfigureAwait(false);
+        using var response = await _httpClient.PostAsync(path.TrimStart('/'), httpContent, ctk).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
             await GetException(response, ctk).ConfigureAwait(false);
 
@@ -850,7 +850,7 @@ public class TypesenseClient : ITypesenseClient
 
     private async Task<T> Patch<T>(string path, HttpContent? httpContent, JsonSerializerOptions? jsonSerializerOptions, CancellationToken ctk = default)
     {
-        using var response = await _httpClient.PatchAsync(path, httpContent, ctk).ConfigureAwait(false);
+        using var response = await _httpClient.PatchAsync(path.TrimStart('/'), httpContent, ctk).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
             await GetException(response, ctk).ConfigureAwait(false);
 
@@ -859,7 +859,7 @@ public class TypesenseClient : ITypesenseClient
 
     private async Task<T> Put<T>(string path, HttpContent? httpContent, JsonSerializerOptions? jsonSerializerOptions, CancellationToken ctk = default)
     {
-        using var response = await _httpClient.PutAsync(path, httpContent, ctk).ConfigureAwait(false);
+        using var response = await _httpClient.PutAsync(path.TrimStart('/'), httpContent, ctk).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
             await GetException(response, ctk).ConfigureAwait(false);
 

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -42,7 +42,8 @@ public class TypesenseClient : ITypesenseClient
         ArgumentNullException.ThrowIfNull(httpClient);
 
         var node = config.Value.Nodes.First();
-        httpClient.BaseAddress = new Uri($"{node.Protocol}://{node.Host}:{node.Port}");
+        UriBuilder typeSenseUriBuilder = new UriBuilder(node.Protocol, node.Host, int.Parse(node.Port), node.AdditionalPath);
+        httpClient.BaseAddress = typeSenseUriBuilder.Uri;
         httpClient.DefaultRequestHeaders.Add("X-TYPESENSE-API-KEY", config.Value.ApiKey);
         _httpClient = httpClient;
         if (config.Value.JsonSerializerOptions is not null)
@@ -416,7 +417,7 @@ public class TypesenseClient : ITypesenseClient
     {
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException("cannot be null empty or whitespace", nameof(name));
-        
+
         // add compact_store query parameter only on false since it is true by default
         var compactStoreQuery = compactStore ? string.Empty : "?compact_store=false";
 


### PR DESCRIPTION
Found inconsistencies of path strings. Some with leading '/' and some are without leading '/'. 
This can cause problems with Uri containing additional paths, such as 404 not found.
Source: [StackOverflow](https://stackoverflow.com/questions/23438416/why-is-httpclient-baseaddress-not-working)