### PR TITLE
fix: fix returnId serialized boolean into "true"/"false"

### DIFF
--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -493,9 +493,9 @@ public class TypesenseClient : ITypesenseClient
             _ => throw new ArgumentException($"Could not handle {nameof(ImportType)} with name '{Enum.GetName(importType)}'", nameof(importType)),
         };
 
-        if (returnId is not null)
+        if (returnId == true)
         {
-            path += $"&return_id={((bool)returnId ? "true" : "false")}";
+            path += "&return_id=true";
         }
 
         using var response = await _httpClient.PostAsync(path, documents).ConfigureAwait(false);


### PR DESCRIPTION
Explicitly calling `Boolean.ToString()` or `$"{Boolean}"` would result in string of either "True" or "False", instead of "true" or "false."

This PR is raised because when I tried to use non-null `returnId` param for `ImportDocuments`, I got an error from Typesense saying the accepted values are `true` or `false` only.

This PR attempts to fix this issue.