### PR TITLE
Refactor document export to support streaming

### DIFF
--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -589,7 +589,9 @@ public class TypesenseClient : ITypesenseClient
         {
             if (string.IsNullOrWhiteSpace(line))
                 continue;
-            
+
+            ctk.ThrowIfCancellationRequested();
+
             yield return JsonSerializer.Deserialize<T>(line, _jsonNameCaseInsensitiveTrue) ??
                          throw new ArgumentException("Null is not valid for documents");
         }


### PR DESCRIPTION
Introduced `ExportDocumentsAsStream<T>` as a new public asynchronous method that streams documents using `IAsyncEnumerable<T>`. This method validates input parameters, constructs URL parameters, and deserializes streamed lines into objects of type `T`.

Refactored the existing document export method to leverage `ExportDocumentsAsStream<T>`, collecting streamed documents into a `List<T>` for backward compatibility.