### PR TITLE
Add support for union search (Typesense v28+)

### DIFF
--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -131,6 +131,23 @@ public interface ITypesenseClient
     Task<SearchGroupedResult<T>> SearchGrouped<T>(string collection, GroupedSearchParameters groupedSearchParameters, CancellationToken ctk = default);
 
     /// <summary>
+    /// The search results returned by each of the search queries in a multi_search
+    /// request can be merged into a single ordered set of hits via the union option.
+    /// </summary>
+    /// <param name="s1">First collection of multi-search parameters.</param>
+    /// <param name="limitMultiSearches">Max number of search requests that can be sent in a multi-search request. Eg: 20. Default is 50.</param>
+    /// <param name="page">The page to retrieve. Default is 1.</param>
+    /// <param name="perPage">Number of results to return per page. Default is 10.</param>
+    /// <param name="ctk">The optional cancellation token.</param>
+    /// <returns>The search results.</returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="TypesenseApiException"></exception>
+    /// <exception cref="TypesenseApiBadRequestException"></exception>
+    /// <exception cref="TypesenseApiNotFoundException"></exception>
+    /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
+    Task<UnionSearchResult<T1>> UnionSearch<T1>(ICollection<MultiSearchParameters> s1, int? limitMultiSearches = null, int? page = null, int? perPage = null, CancellationToken ctk = default);
+
+    /// <summary>
     /// Multiple Searches for documents in the specified collections using the supplied search parameters.
     /// </summary>
     /// <param name="s1">First collection of multi-search parameters.</param>

--- a/src/Typesense/SearchParameters.cs
+++ b/src/Typesense/SearchParameters.cs
@@ -615,3 +615,44 @@ public record GroupedSearchParameters : SearchParameters
         GroupBy = groupBy;
     }
 }
+
+/// <summary>
+/// Parameters used for performing a Union search,
+/// where results from multiple searches are combined into a single
+/// unified result set and then paginated.
+/// See: https://typesense.org/docs/30.1/api/federated-multi-search.html#union-search
+/// </summary>
+public record UnionSearchParameters
+{
+    /// <summary>
+    /// Limits the number of individual searches from a multi-search request
+    /// that are considered when generating the unified result set.
+    /// This can be used to control performance when many searches are included.
+    /// </summary>
+    [JsonPropertyName("limit_multi_searches")]
+    public int? LimitMultiSearches { get; init; }
+
+    /// <summary>
+    /// Page number of the merged (unioned) result set to return.
+    /// Pagination is applied after results from all searches are combined.
+    /// </summary>
+    [JsonPropertyName("page")]
+    public int? Page { get; init; }
+
+    /// <summary>
+    /// Number of results to return per page from the unified result set.
+    /// Pagination is applied after merging results from all searches.
+    /// </summary>
+    [JsonPropertyName("per_page")]
+    public int? PerPage { get; init; }
+
+    public UnionSearchParameters(
+        int? limitMultiSearches = null,
+        int? page = null,
+        int? perPage = null)
+    {
+        LimitMultiSearches = limitMultiSearches;
+        Page = page;
+        PerPage = perPage;
+    }
+}

--- a/src/Typesense/SearchResult.cs
+++ b/src/Typesense/SearchResult.cs
@@ -352,3 +352,67 @@ public record MultiSearchResult<T>
         ErrorMessage = errorMessage;
     }
 }
+
+public record UnionSearchResult<T> : MultiSearchResult<T>
+{
+    [JsonPropertyName("union_request_params")]
+    public IReadOnlyList<UnionRequestParam>? UnionRequestParams { get; init; }
+
+    [JsonConstructor]
+    public UnionSearchResult(
+        IReadOnlyList<FacetCount>? facetCounts,
+        int? found,
+        IReadOnlyList<Hit<T>>? hits,
+        int? outOf,
+        int? page,
+        bool? searchCutoff,
+        int? searchTimeMs,
+        int? errorCode,
+        string? errorMessage,
+        IReadOnlyList<UnionRequestParam>? unionRequestParams) : base(
+        facetCounts,
+        found,
+        hits,
+        outOf,
+        page,
+        searchCutoff,
+        searchTimeMs,
+        errorCode,
+        errorMessage)
+    {
+        UnionRequestParams = unionRequestParams;
+    }
+}
+
+public record UnionRequestParam
+{
+    [JsonPropertyName("collection")]
+    public string? Collection { get; init; }
+
+    [JsonPropertyName("first_q")]
+    public string? FirstQ { get; init; }
+
+    [JsonPropertyName("found")]
+    public int? Found { get; init; }
+
+    [JsonPropertyName("per_page")]
+    public int? PerPage { get; init; }
+
+    [JsonPropertyName("q")]
+    public string? Q { get; init; }
+
+    [JsonConstructor]
+    public UnionRequestParam(
+        string? collection,
+        string? firstQ,
+        int? found,
+        string? q,
+        int? perPage)
+    {
+        Collection = collection;
+        FirstQ = firstQ;
+        Found = found;
+        Q = q;
+        PerPage = perPage;
+    }
+}


### PR DESCRIPTION
Add support for [union search](https://typesense.org/docs/30.1/api/federated-multi-search.html#union-search) introduced in version 28.0.

- Introduce `UnionSearchParameters`, `UnionSearchResult<T>` record types.
- Extend the `ITypesenseClient` interface and the `TypesenseClient` implementation with a new `UnionSearch<T1>` method.
- Pagination parameters are passed as query parameters as per the documentation and the `union` boolean parameter is passed in the request body with a value of `true`.