### PR TITLE
Fix UseCache parameter for MutliSearch and fix CacheTTL value to not be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ var provider = new ServiceCollection()
     .AddTypesenseClient(config =>
     {
         config.ApiKey = "mysecretapikey";
+        config.SearchApiKey = "mysearchonlyapikey"; // optional
         config.Nodes = new List<Node>
         {
             new Node("localhost", "8108", "http")
@@ -150,6 +151,18 @@ var queryThree = new MultiSearchParameters("companies", "Awesome Corp.", "compan
 
 var (r1, r2, r3) = await _client.MultiSearch<Company, Employee, Company>(queryOne, queryTwo, queryThree);
 ```
+
+## Search with Scoped Search key
+
+```c#
+var searchResults = await _client
+    .WithSearchScope(new ScopedSearchParameters { CacheTtl = 10 })
+    .MultiSearch<object>(searchParameters);
+```
+
+> **Note** To use the `WithSearchScope` method, the `SearchApiKey` property in the `Config` object must be set. The key **must only have the `documents:search` permission** and no other permissions.
+
+> **Note:** The `cache_ttl` parameter can only be set and enforced via a scoped search key. If passed directly in search parameters, its value will be ignored and the default of `60` (seconds) will be used instead.
 
 ## Vector search
 

--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -9,6 +9,20 @@ namespace Typesense;
 public interface ITypesenseClient
 {
     /// <summary>
+    /// Creates a new <see cref="ITypesenseClient"/> instance that uses a scoped
+    /// search key derived from the scoped search parameters and the search API key.
+    /// The original client instance is not modified.
+    /// Precondition: <c>SearchApiKey</c> must be set in <c>Config</c> and must 
+    /// have no other permissions besides <c>documents:search</c>.
+    /// Note: Parameters embedded in the scoped search parameters will be automatically applied by Typesense and users will not be able to override them.
+    /// </summary>
+    /// <param name="scopedSearchParameters">The scoped search parameters object.</param>
+    /// <returns>A new <see cref="ITypesenseClient"/> configured with the scoped search key.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <c>SearchApiKey</c> is not set in <c>Config</c> or does not meet permission requirements.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="scopedSearchParameters"/> is null.</exception>
+    ITypesenseClient WithSearchScope(ScopedSearchParameters scopedSearchParameters);
+
+    /// <summary>
     /// Creates the collection with the supplied schema
     /// </summary>
     /// <param name="schema">The schema for the collection be created.</param>
@@ -23,7 +37,7 @@ public interface ITypesenseClient
     Task<CollectionResponse> CreateCollection(Schema schema);
 
     /// <summary>
-    /// Rmove all documents from a collection but keeps the collection and schema intact.
+    /// Remove all documents from a collection but keeps the collection and schema intact.
     /// </summary>
     /// <param name="collection">The name of the collection to truncate.</param>
     /// <returns>The response object includes the number of documents that were deleted. For an empty collection, this value will be 0.</returns>
@@ -37,7 +51,7 @@ public interface ITypesenseClient
     Task<TruncateCollectionResponse> TruncateCollection(string collection);
 
     /// <summary>
-    /// Creates the document in the speicfied collection.
+    /// Creates the document in the specified collection.
     /// </summary>
     /// <param name="collection">The collection name.</param>
     /// <param name="document">The document to be inserted. The document should be in JSON format.</param>
@@ -53,7 +67,7 @@ public interface ITypesenseClient
     Task<T> CreateDocument<T>(string collection, string document) where T : class;
 
     /// <summary>
-    /// Creates the document in the speicfied collection.
+    /// Creates the document in the specified collection.
     /// </summary>
     /// <param name="collection">The collection name.</param>
     /// <param name="document">The document to be inserted.</param>
@@ -461,7 +475,7 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
     Task<FilterUpdateResponse> UpdateDocuments<T>(string collection, T document, string filter, bool fullUpdate = false);
-    
+
     /// <summary>
     /// Batch import documents.
     /// </summary>

--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -37,7 +37,7 @@ public interface ITypesenseClient
     Task<CollectionResponse> CreateCollection(Schema schema);
 
     /// <summary>
-    /// Remove all documents from a collection but keeps the collection and schema intact.
+    /// Rmove all documents from a collection but keeps the collection and schema intact.
     /// </summary>
     /// <param name="collection">The name of the collection to truncate.</param>
     /// <returns>The response object includes the number of documents that were deleted. For an empty collection, this value will be 0.</returns>
@@ -51,7 +51,7 @@ public interface ITypesenseClient
     Task<TruncateCollectionResponse> TruncateCollection(string collection);
 
     /// <summary>
-    /// Creates the document in the specified collection.
+    /// Creates the document in the speicfied collection.
     /// </summary>
     /// <param name="collection">The collection name.</param>
     /// <param name="document">The document to be inserted. The document should be in JSON format.</param>
@@ -67,7 +67,7 @@ public interface ITypesenseClient
     Task<T> CreateDocument<T>(string collection, string document) where T : class;
 
     /// <summary>
-    /// Creates the document in the specified collection.
+    /// Creates the document in the speicfied collection.
     /// </summary>
     /// <param name="collection">The collection name.</param>
     /// <param name="document">The document to be inserted.</param>
@@ -475,7 +475,7 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
     Task<FilterUpdateResponse> UpdateDocuments<T>(string collection, T document, string filter, bool fullUpdate = false);
-
+    
     /// <summary>
     /// Batch import documents.
     /// </summary>

--- a/src/Typesense/ScopedSearchParameters.cs
+++ b/src/Typesense/ScopedSearchParameters.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace Typesense;
+
+public record ScopedSearchParameters
+{
+    /// <summary>
+    /// The duration (in seconds) that determines how long the search query is cached.
+    /// This value can only be set as part of a scoped API key.
+    /// Default: 60
+    /// </summary>
+    [JsonPropertyName("cache_ttl")]
+    public int? CacheTtl { get; init; }
+}

--- a/src/Typesense/SearchParameters.cs
+++ b/src/Typesense/SearchParameters.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 using Typesense.Converter;
 
@@ -47,6 +49,42 @@ public record MultiSearchParameters : SearchParameters
     {
         Collection = collection;
     }
+}
+
+public record MultiSearchQueryParameters
+{
+    /// <summary>
+    /// Limits the number of individual searches from a multi-search request
+    /// that are considered when generating the unified result set.
+    /// This can be used to control performance when many searches are included.
+    /// </summary>
+    [JsonPropertyName("limit_multi_searches")]
+    public int? LimitMultiSearches { get; init; }
+
+    /// <summary>
+    /// Enable server side caching of search query results. By default, caching is disabled.
+    /// Default: false
+    /// </summary>
+    [JsonPropertyName("use_cache")]
+    public bool? UseCache { get; init; }
+
+    /// <summary>
+    /// Results from this specific page number would be fetched.
+    /// </summary>
+    [JsonPropertyName("page")]
+    public int? Page { get; init; }
+
+    /// <summary>
+    /// Number of results to fetch per page. Default: 10
+    /// </summary>
+    [JsonPropertyName("per_page")]
+    public int? PerPage { get; init; }
+
+    public MultiSearchQueryParameters(ICollection<MultiSearchParameters> searches) =>
+        UseCache = searches.Select(s => s.UseCache).FirstOrDefault(v => v.HasValue);
+
+    public MultiSearchQueryParameters(params MultiSearchParameters[] searches)
+        : this((ICollection<MultiSearchParameters>)searches) { }
 }
 
 public record SearchParameters
@@ -537,7 +575,7 @@ public record SearchParameters
     /// </summary>
     [JsonPropertyName("remote_embedding_timeout_ms")]
     public int? RemoteEmbeddingTimeoutMs { get; set; }
-    
+
     /// <summary>
     /// When set to true, enables both text match and vector distance scores to be computed for all hybrid search results,
     /// improving the ranking by combining both score types for documents found only by keyword or vector search

--- a/src/Typesense/Setup/Config.cs
+++ b/src/Typesense/Setup/Config.cs
@@ -8,6 +8,7 @@ public record Config
 {
     public IReadOnlyCollection<Node> Nodes { get; set; }
     public string ApiKey { get; set; }
+    public string? SearchApiKey { get; set; }
     public JsonSerializerOptions? JsonSerializerOptions { get; set; }
 
     [Obsolete("Use multi-arity constructor instead.")]
@@ -15,11 +16,13 @@ public record Config
     {
         Nodes = new List<Node>();
         ApiKey = "";
+        SearchApiKey = null;
     }
 
-    public Config(IReadOnlyCollection<Node> nodes, string apiKey)
+    public Config(IReadOnlyCollection<Node> nodes, string apiKey, string? searchApiKey = null)
     {
         Nodes = nodes;
         ApiKey = apiKey;
+        SearchApiKey = searchApiKey;
     }
 }

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -23,8 +23,10 @@ namespace Typesense;
 
 public class TypesenseClient : ITypesenseClient
 {
+    private const string ApiKeyHeaderName = "X-TYPESENSE-API-KEY";
     private static readonly MediaTypeHeaderValue JsonMediaTypeHeaderValue = MediaTypeHeaderValue.Parse($"{MediaTypeNames.Application.Json};charset={Encoding.UTF8.WebName}");
     private readonly HttpClient _httpClient;
+    private readonly string? _searchApiKey;
 
     private readonly JsonSerializerOptions _jsonSerializerDefault = new();
 
@@ -44,7 +46,8 @@ public class TypesenseClient : ITypesenseClient
         var node = config.Value.Nodes.First();
         UriBuilder typeSenseUriBuilder = new UriBuilder(node.Protocol, node.Host, int.Parse(node.Port), node.AdditionalPath);
         httpClient.BaseAddress = typeSenseUriBuilder.Uri;
-        httpClient.DefaultRequestHeaders.Add("X-TYPESENSE-API-KEY", config.Value.ApiKey);
+        httpClient.DefaultRequestHeaders.Add(ApiKeyHeaderName, config.Value.ApiKey);
+        _searchApiKey = config.Value.SearchApiKey;
 
         _httpClient = httpClient;
 
@@ -61,6 +64,33 @@ public class TypesenseClient : ITypesenseClient
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
             };
         }
+    }
+
+    private TypesenseClient(TypesenseClient source, string apiKey)
+    {
+        var newHttpClient = new HttpClient
+        {
+            BaseAddress = source._httpClient.BaseAddress,
+            DefaultRequestVersion = source._httpClient.DefaultRequestVersion,
+        };
+        newHttpClient.DefaultRequestHeaders.Add(ApiKeyHeaderName, apiKey);
+
+        _httpClient = newHttpClient;
+        _jsonSerializerDefault = source._jsonSerializerDefault;
+        _jsonNameCaseInsensitiveTrue = source._jsonNameCaseInsensitiveTrue;
+        _jsonOptionsCamelCaseIgnoreWritingNull = source._jsonOptionsCamelCaseIgnoreWritingNull;
+    }
+
+    public ITypesenseClient WithSearchScope(ScopedSearchParameters scopedSearchParameters)
+    {
+        ArgumentNullException.ThrowIfNull(scopedSearchParameters, nameof(scopedSearchParameters));
+        var searchApiKey = _searchApiKey ?? throw new InvalidOperationException(
+            "SearchApiKey must be set in Config to use WithSearchScope.");
+
+        var serializedScope = JsonSerializer.Serialize(scopedSearchParameters, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var scopedApiKey = GenerateScopedSearchKey(searchApiKey, serializedScope);
+
+        return new TypesenseClient(this, scopedApiKey);
     }
 
     public async Task<CollectionResponse> CreateCollection(Schema schema)

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -45,7 +45,7 @@ public class TypesenseClient : ITypesenseClient
         UriBuilder typeSenseUriBuilder = new UriBuilder(node.Protocol, node.Host, int.Parse(node.Port), node.AdditionalPath);
         httpClient.BaseAddress = typeSenseUriBuilder.Uri;
         httpClient.DefaultRequestHeaders.Add("X-TYPESENSE-API-KEY", config.Value.ApiKey);
-        
+
         _httpClient = httpClient;
 
         if (config.Value.JsonSerializerOptions is not null)
@@ -153,17 +153,13 @@ public class TypesenseClient : ITypesenseClient
         var body = new { union = true, Searches = s1 };
         using var json = JsonContent.Create(body, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
 
-        var queryParams = new UnionSearchParameters
+        var queryString = CreateUrlParameters(new MultiSearchQueryParameters(s1)
         {
             LimitMultiSearches = limitMultiSearches,
             Page = page,
             PerPage = perPage
-        };
-        var queryString = CreateUrlParameters(queryParams);
-
-        var path = queryString.Length == 0 
-            ? "/multi_search" 
-            : $"/multi_search?{queryString}";
+        });
+        var path = queryString.Length == 0 ? "/multi_search" : $"/multi_search?{queryString}";
 
         var response = await Post<JsonElement>(path, json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
@@ -176,9 +172,11 @@ public class TypesenseClient : ITypesenseClient
         var searches = new { Searches = s1 };
         using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
 
-        var path = limitMultiSearches is null
-            ? "/multi_search"
-            : $"/multi_search?limit_multi_searches={limitMultiSearches}";
+        var queryString = CreateUrlParameters(new MultiSearchQueryParameters(s1)
+        {
+            LimitMultiSearches = limitMultiSearches
+        });
+        var path = queryString.Length == 0 ? "/multi_search" : $"/multi_search?{queryString}";
 
         var response = await Post<JsonElement>(path, json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
@@ -191,7 +189,9 @@ public class TypesenseClient : ITypesenseClient
     {
         var searches = new { Searches = new MultiSearchParameters[] { s1 } };
         using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var queryString = CreateUrlParameters(new MultiSearchQueryParameters(s1));
+        var path = queryString.Length == 0 ? "/multi_search" : $"/multi_search?{queryString}";
+        var response = await Post<JsonElement>(path, json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
         return response.TryGetProperty("results", out var results)
             ? HandleDeserializeMultiSearch<T>(results[0])
@@ -202,7 +202,9 @@ public class TypesenseClient : ITypesenseClient
     {
         var searches = new { Searches = new MultiSearchParameters[] { s1, s2 } };
         using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var queryString = CreateUrlParameters(new MultiSearchQueryParameters(s1, s2));
+        var path = queryString.Length == 0 ? "/multi_search" : $"/multi_search?{queryString}";
+        var response = await Post<JsonElement>(path, json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
         return response.TryGetProperty("results", out var results)
             ? (HandleDeserializeMultiSearch<T1>(results[0]),
@@ -218,7 +220,9 @@ public class TypesenseClient : ITypesenseClient
     {
         var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3 } };
         using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var queryString = CreateUrlParameters(new MultiSearchQueryParameters(s1, s2, s3));
+        var path = queryString.Length == 0 ? "/multi_search" : $"/multi_search?{queryString}";
+        var response = await Post<JsonElement>(path, json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
         return response.TryGetProperty("results", out var results)
             ? (HandleDeserializeMultiSearch<T1>(results[0]),
@@ -236,7 +240,9 @@ public class TypesenseClient : ITypesenseClient
     {
         var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4 } };
         using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var queryString = CreateUrlParameters(new MultiSearchQueryParameters(s1, s2, s3, s4));
+        var path = queryString.Length == 0 ? "/multi_search" : $"/multi_search?{queryString}";
+        var response = await Post<JsonElement>(path, json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
         return (response.TryGetProperty("results", out var results))
             ? (HandleDeserializeMultiSearch<T1>(results[0]),
@@ -256,7 +262,9 @@ public class TypesenseClient : ITypesenseClient
     {
         var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5 } };
         using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var queryString = CreateUrlParameters(new MultiSearchQueryParameters(s1, s2, s3, s4, s5));
+        var path = queryString.Length == 0 ? "/multi_search" : $"/multi_search?{queryString}";
+        var response = await Post<JsonElement>(path, json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
         return response.TryGetProperty("results", out var results)
             ? (HandleDeserializeMultiSearch<T1>(results[0]),
@@ -278,7 +286,9 @@ public class TypesenseClient : ITypesenseClient
     {
         var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5, s6 } };
         using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var queryString = CreateUrlParameters(new MultiSearchQueryParameters(s1, s2, s3, s4, s5, s6));
+        var path = queryString.Length == 0 ? "/multi_search" : $"/multi_search?{queryString}";
+        var response = await Post<JsonElement>(path, json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
         return response.TryGetProperty("results", out var results)
             ? (HandleDeserializeMultiSearch<T1>(results[0]),
@@ -302,7 +312,9 @@ public class TypesenseClient : ITypesenseClient
     {
         var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5, s6, s7 } };
         using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var queryString = CreateUrlParameters(new MultiSearchQueryParameters(s1, s2, s3, s4, s5, s6, s7));
+        var path = queryString.Length == 0 ? "/multi_search" : $"/multi_search?{queryString}";
+        var response = await Post<JsonElement>(path, json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
         return response.TryGetProperty("results", out var results)
             ? (HandleDeserializeMultiSearch<T1>(results[0]),
@@ -328,7 +340,9 @@ public class TypesenseClient : ITypesenseClient
     {
         var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5, s6, s7, s8 } };
         using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var queryString = CreateUrlParameters(new MultiSearchQueryParameters(s1, s2, s3, s4, s5, s6, s7, s8));
+        var path = queryString.Length == 0 ? "/multi_search" : $"/multi_search?{queryString}";
+        var response = await Post<JsonElement>(path, json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
         return response.TryGetProperty("results", out var results)
             ? (HandleDeserializeMultiSearch<T1>(results[0]),
@@ -356,7 +370,9 @@ public class TypesenseClient : ITypesenseClient
     {
         var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5, s6, s7, s8, s9 } };
         using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var queryString = CreateUrlParameters(new MultiSearchQueryParameters(s1, s2, s3, s4, s5, s6, s7, s8, s9));
+        var path = queryString.Length == 0 ? "/multi_search" : $"/multi_search?{queryString}";
+        var response = await Post<JsonElement>(path, json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
         return response.TryGetProperty("results", out var results)
             ? (HandleDeserializeMultiSearch<T1>(results[0]),

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -7,6 +8,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using Typesense.Setup;
 using Xunit;
 
 namespace Typesense.Tests;
@@ -2011,8 +2013,8 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
             "fruit-synonyms",
             [
                 new SynonymSchema(
-                    "apple-synonyms", 
-                    ["appl", "aple", "apple"], 
+                    "apple-synonyms",
+                    ["appl", "aple", "apple"],
                     "apple",
                     null,
                     ["+"]
@@ -2115,7 +2117,7 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
                 rule: new Rule("apple", "exact"),
                 id: "customize-apple"
             )
-        ]);        
+        ]);
 
         var schema = new CurationSetSchema(
         [
@@ -2575,6 +2577,107 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
     {
         var response = await _client.TruncateCollection("companies");
         response.NumDeleted.Should().BeGreaterThan(0);
+    }
+
+    [Fact, TestPriority(48)]
+    public async Task MultiSearch_with_cache_returns_stale_results_until_ttl_expires()
+    {
+        const string collectionName = "cache-test-companies";
+        const int cacheTtlSeconds = 2;
+
+        // Setup: create a dedicated collection.
+        var schema = new Schema(
+            collectionName,
+            new List<Field>
+            {
+                new Field("company_name", FieldType.String, false),
+                new Field("num_employees", FieldType.Int32, true),
+            },
+            "num_employees");
+
+        await _client.CreateCollection(schema);
+
+        // Insert initial document.
+        await _client.CreateDocument(collectionName, new Company
+        {
+            Id = "1",
+            CompanyName = "Original Corp",
+            NumEmployees = 100,
+        });
+
+        // Create a search-only API key (required for WithSearchScope).
+        var searchKey = await _client.CreateKey(
+            new Key("Cache test search key", ["documents:search"], ["*"]));
+
+        try
+        {
+            // Build a client that has the SearchApiKey configured.
+            var clientWithSearchKey = new ServiceCollection()
+                .AddTypesenseClient(config =>
+                {
+                    config.ApiKey = "key";
+                    config.SearchApiKey = searchKey.Value;
+                    config.Nodes = new List<Node>
+                    {
+                        new Node("localhost", "8108", "http")
+                    };
+                }).BuildServiceProvider().GetService<ITypesenseClient>();
+
+            // Create a scoped client with cache_ttl embedded in the API key.
+            var cachedClient = clientWithSearchKey
+                .WithSearchScope(new ScopedSearchParameters { CacheTtl = cacheTtlSeconds });
+
+            var query = new MultiSearchParameters(collectionName, "*", "company_name")
+            {
+                UseCache = true
+            };
+
+            // 1st search: populates the cache.
+            var result1 = await cachedClient.MultiSearch<Company>(query);
+
+            using (new AssertionScope())
+            {
+                result1.Found.Should().Be(1);
+                result1.Hits.First().Document.CompanyName.Should().Be("Original Corp");
+            }
+
+            // Mutate the data (via admin client, which has write permissions).
+            await _client.UpsertDocument(collectionName, new Company
+            {
+                Id = "1",
+                CompanyName = "Updated Corp",
+                NumEmployees = 100,
+            });
+
+            // 2nd search: should return cached (stale) result.
+            var result2 = await cachedClient.MultiSearch<Company>(query);
+
+            using (new AssertionScope())
+            {
+                result2.Found.Should().Be(1);
+                result2.Hits[0].Document.CompanyName
+                    .Should().Be("Original Corp", "result should be served from cache");
+            }
+
+            // Wait for the cache to expire.
+            await Task.Delay(TimeSpan.FromSeconds(cacheTtlSeconds + 1));
+
+            // 3rd search: cache expired, should return fresh data.
+            var result3 = await cachedClient.MultiSearch<Company>(query);
+
+            using (new AssertionScope())
+            {
+                result3.Found.Should().Be(1);
+                result3.Hits[0].Document.CompanyName
+                    .Should().Be("Updated Corp", "cache should have expired");
+            }
+        }
+        finally
+        {
+            // Cleanup.
+            await _client.DeleteCollection(collectionName);
+            await _client.DeleteKey(searchKey.Id);
+        }
     }
 
     private async Task CreateCompanyCollection()


### PR DESCRIPTION
To fix this [issue](https://github.com/DAXGRID/typesense-dotnet/issues/306) according to the related Typesense docs we:

1) Created the `MultiSearchQueryParameters` record type, to specify which parameters need to be passed as query parameters in multi-search as [some parameters](https://typesense.org/docs/30.1/api/search.html#caching-parameters) when passed in the request body are ignored by Typesense (ex: the `use_cache` boolean).
2) Created the instance method `WithSearchScope` that takes a `ScopedSearchParameters` instance, uses a Search API key (i.e. an API key with only `document:search` permission) to generate a [scoped api key with the embedded parameters](https://typesense.org/docs/30.1/api/api-keys.html#generate-scoped-search-key) and return a new `TypesenseClient` instance that uses the generated API key instead of the default one. (This is the only way to specify a custom `cache_ttl` parameter).
3) Created the `ScopedSearchParameters` record type, to specify which parameters the user can embed when generating the scoped search key. 
4) Added a `SearchApiKey` optional property in the `Config` class.
5) Added an example usage in the `README.md` file.

These changes are meant to be backwards-compatible (no breaking changes).