### PR TITLE
Support caching multi search.

### DIFF
--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -151,7 +151,7 @@ public interface ITypesenseClient
     /// Multiple Searches for documents in the specified collections using the supplied search parameters.
     /// </summary>
     /// <param name="s1">First collection of multi-search parameters.</param>
-    /// <param name="limitMultiSearches">Max number of search requests that can be sent in a multi-search request. Eg: 20. Default is 50.</param>
+    /// <param name="parms">Common multi-search parameters.</param>
     /// <param name="ctk">The optional cancellation token.</param>
     /// <returns>The search results.</returns>
     /// <exception cref="InvalidOperationException"></exception>
@@ -159,12 +159,13 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiBadRequestException"></exception>
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
-    Task<List<MultiSearchResult<T1>>> MultiSearch<T1>(ICollection<MultiSearchParameters> s1, int? limitMultiSearches = null, CancellationToken ctk = default);
+    Task<List<MultiSearchResult<T1>>> MultiSearch<T1>(ICollection<MultiSearchParameters> s1, CommonMultiSearchParameters? parms = null, CancellationToken ctk = default);
 
     /// <summary>
     /// Multiple Searches for documents in the specified collections using the supplied search parameters.
     /// </summary>
     /// <param name="s1">First multi-search parameters.</param>
+    /// <param name="parms">Common multi-search parameters.</param>
     /// <param name="ctk">The optional cancellation token.</param>
     /// <returns>The search results.</returns>
     /// <exception cref="InvalidOperationException"></exception>
@@ -172,13 +173,14 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiBadRequestException"></exception>
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
-    Task<MultiSearchResult<T1>> MultiSearch<T1>(MultiSearchParameters s1, CancellationToken ctk = default);
+    Task<MultiSearchResult<T1>> MultiSearch<T1>(MultiSearchParameters s1, CommonMultiSearchParameters? parms = null, CancellationToken ctk = default);
 
     /// <summary>
     /// Multiple Searches for documents in the specified collections using the supplied search parameters.
     /// </summary>
     /// <param name="s1">First multi-search parameters.</param>
     /// <param name="s2">Second multi-search parameters.</param>
+    /// <param name="parms">Common multi-search parameters.</param>
     /// <param name="ctk">The optional cancellation token.</param>
     /// <returns>The search results.</returns>
     /// <exception cref="InvalidOperationException"></exception>
@@ -186,7 +188,7 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiBadRequestException"></exception>
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
-    Task<(MultiSearchResult<T1>, MultiSearchResult<T2>)> MultiSearch<T1, T2>(MultiSearchParameters s1, MultiSearchParameters s2, CancellationToken ctk = default);
+    Task<(MultiSearchResult<T1>, MultiSearchResult<T2>)> MultiSearch<T1, T2>(MultiSearchParameters s1, MultiSearchParameters s2, CommonMultiSearchParameters? parms = null, CancellationToken ctk = default);
 
     /// <summary>
     /// Multiple Searches for documents in the specified collections using the supplied search parameters.
@@ -194,6 +196,7 @@ public interface ITypesenseClient
     /// <param name="s1">First multi-search parameters.</param>
     /// <param name="s2">Second multi-search parameters.</param>
     /// <param name="s3">Third multi-search parameters.</param>
+    /// <param name="parms">Common multi-search parameters.</param>
     /// <param name="ctk">The optional cancellation token.</param>
     /// <returns>The search results.</returns>
     /// <exception cref="InvalidOperationException"></exception>
@@ -202,7 +205,7 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
     Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>)> MultiSearch<T1, T2, T3>
-        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, CancellationToken ctk = default);
+        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, CommonMultiSearchParameters? parms = null, CancellationToken ctk = default);
 
     /// <summary>
     /// Multiple Searches for documents in the specified collections using the supplied search parameters.
@@ -211,6 +214,7 @@ public interface ITypesenseClient
     /// <param name="s2">Second multi-search parameters.</param>
     /// <param name="s3">Third multi-search parameters.</param>
     /// <param name="s4">Fourth multi-search parameters.</param>
+    /// <param name="parms">Common multi-search parameters.</param>
     /// <param name="ctk">The optional cancellation token.</param>
     /// <returns>The search results.</returns>
     /// <exception cref="InvalidOperationException"></exception>
@@ -219,7 +223,7 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
     Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>)> MultiSearch<T1, T2, T3, T4>
-        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, CancellationToken ctk = default);
+        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, CommonMultiSearchParameters? parms = null, CancellationToken ctk = default);
 
     /// <summary>
     /// Multiple Searches for documents in the specified collections using the supplied search parameters.
@@ -229,6 +233,7 @@ public interface ITypesenseClient
     /// <param name="s3">Third multi-search parameters.</param>
     /// <param name="s4">Fourth multi-search parameters.</param>
     /// <param name="s5">Fifth multi-search parameters.</param>
+    /// <param name="parms">Common multi-search parameters.</param>
     /// <param name="ctk">The optional cancellation token.</param>
     /// <returns>The search results.</returns>
     /// <exception cref="InvalidOperationException"></exception>
@@ -237,7 +242,7 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
     Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>)> MultiSearch<T1, T2, T3, T4, T5>
-        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, CancellationToken ctk = default);
+        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, CommonMultiSearchParameters? parms = null, CancellationToken ctk = default);
 
     /// <summary>
     /// Multiple Searches for documents in the specified collections using the supplied search parameters.
@@ -248,6 +253,7 @@ public interface ITypesenseClient
     /// <param name="s4">Fourth multi-search parameters.</param>
     /// <param name="s5">Fifth multi-search parameters.</param>
     /// <param name="s6">Sixth multi-search parameters.</param>
+    /// <param name="parms">Common multi-search parameters.</param>
     /// <param name="ctk">The optional cancellation token.</param>
     /// <returns>The search results.</returns>
     /// <exception cref="InvalidOperationException"></exception>
@@ -256,7 +262,7 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
     Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>)> MultiSearch<T1, T2, T3, T4, T5, T6>
-        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, MultiSearchParameters s6, CancellationToken ctk = default);
+        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, MultiSearchParameters s6, CommonMultiSearchParameters? parms = null, CancellationToken ctk = default);
 
     /// <summary>
     /// Multiple Searches for documents in the specified collections using the supplied search parameters.
@@ -268,6 +274,7 @@ public interface ITypesenseClient
     /// <param name="s5">Fifth multi-search parameters.</param>
     /// <param name="s6">Sixth multi-search parameters.</param>
     /// <param name="s7">Seventh multi-search parameters.</param>
+    /// <param name="parms">Common multi-search parameters.</param>
     /// <param name="ctk">The optional cancellation token.</param>
     /// <returns>The search results.</returns>
     /// <exception cref="InvalidOperationException"></exception>
@@ -276,7 +283,7 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
     Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>, MultiSearchResult<T7>)> MultiSearch<T1, T2, T3, T4, T5, T6, T7>
-        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, MultiSearchParameters s6, MultiSearchParameters s7, CancellationToken ctk = default);
+        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, MultiSearchParameters s6, MultiSearchParameters s7, CommonMultiSearchParameters? parms = null, CancellationToken ctk = default);
 
     /// <summary>
     /// Multiple Searches for documents in the specified collections using the supplied search parameters.
@@ -289,6 +296,7 @@ public interface ITypesenseClient
     /// <param name="s6">Sixth multi-search parameters.</param>
     /// <param name="s7">Seventh multi-search parameters.</param>
     /// <param name="s8">Eighth multi-search parameters.</param>
+    /// <param name="parms">Common multi-search parameters.</param>
     /// <param name="ctk">The optional cancellation token.</param>
     /// <returns>The search results.</returns>
     /// <exception cref="InvalidOperationException"></exception>
@@ -297,7 +305,7 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
     Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>, MultiSearchResult<T7>, MultiSearchResult<T8>)> MultiSearch<T1, T2, T3, T4, T5, T6, T7, T8>
-        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, MultiSearchParameters s6, MultiSearchParameters s7, MultiSearchParameters s8, CancellationToken ctk = default);
+        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, MultiSearchParameters s6, MultiSearchParameters s7, MultiSearchParameters s8, CommonMultiSearchParameters? parms = null, CancellationToken ctk = default);
 
     /// <summary>
     /// Multiple Searches for documents in the specified collections using the supplied search parameters.
@@ -311,6 +319,7 @@ public interface ITypesenseClient
     /// <param name="s7">Seventh multi-search parameters.</param>
     /// <param name="s8">Eighth multi-search parameters.</param>
     /// <param name="s9">Ninth multi-search parameters.</param>
+    /// <param name="parms">Common multi-search parameters.</param>
     /// <param name="ctk">The optional cancellation token.</param>
     /// <returns>The search results.</returns>
     /// <exception cref="InvalidOperationException"></exception>
@@ -319,7 +328,7 @@ public interface ITypesenseClient
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
     Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>, MultiSearchResult<T7>, MultiSearchResult<T8>, MultiSearchResult<T9>)> MultiSearch<T1, T2, T3, T4, T5, T6, T7, T8, T9>
-        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, MultiSearchParameters s6, MultiSearchParameters s7, MultiSearchParameters s8, MultiSearchParameters s9, CancellationToken ctk = default);
+        (MultiSearchParameters s1, MultiSearchParameters s2, MultiSearchParameters s3, MultiSearchParameters s4, MultiSearchParameters s5, MultiSearchParameters s6, MultiSearchParameters s7, MultiSearchParameters s8, MultiSearchParameters s9, CommonMultiSearchParameters? parms = null, CancellationToken ctk = default);
 
     /// <summary>
     /// Gets the document in the specified collection on id.

--- a/src/Typesense/ITypesenseClient.cs
+++ b/src/Typesense/ITypesenseClient.cs
@@ -135,17 +135,14 @@ public interface ITypesenseClient
     /// request can be merged into a single ordered set of hits via the union option.
     /// </summary>
     /// <param name="s1">First collection of multi-search parameters.</param>
-    /// <param name="limitMultiSearches">Max number of search requests that can be sent in a multi-search request. Eg: 20. Default is 50.</param>
-    /// <param name="page">The page to retrieve. Default is 1.</param>
-    /// <param name="perPage">Number of results to return per page. Default is 10.</param>
-    /// <param name="ctk">The optional cancellation token.</param>
+    /// <param name="parms">Common union search parameters.</param>
     /// <returns>The search results.</returns>
     /// <exception cref="InvalidOperationException"></exception>
     /// <exception cref="TypesenseApiException"></exception>
     /// <exception cref="TypesenseApiBadRequestException"></exception>
     /// <exception cref="TypesenseApiNotFoundException"></exception>
     /// <exception cref="TypesenseApiServiceUnavailableException"></exception>
-    Task<UnionSearchResult<T1>> UnionSearch<T1>(ICollection<MultiSearchParameters> s1, int? limitMultiSearches = null, int? page = null, int? perPage = null, CancellationToken ctk = default);
+    Task<UnionSearchResult<T1>> UnionSearch<T1>(ICollection<MultiSearchParameters> s1, UnionSearchParameters? parms = null, CancellationToken ctk = default);
 
     /// <summary>
     /// Multiple Searches for documents in the specified collections using the supplied search parameters.

--- a/src/Typesense/SearchParameters.cs
+++ b/src/Typesense/SearchParameters.cs
@@ -610,61 +610,6 @@ public record GroupedSearchParameters : SearchParameters
 }
 
 /// <summary>
-/// Parameters used for performing a Union search,
-/// where results from multiple searches are combined into a single
-/// unified result set and then paginated.
-/// See: https://typesense.org/docs/30.1/api/federated-multi-search.html#union-search
-/// </summary>
-public record UnionSearchParameters
-{
-    /// <summary>
-    /// Limits the number of individual searches from a multi-search request
-    /// that are considered when generating the unified result set.
-    /// This can be used to control performance when many searches are included.
-    /// </summary>
-    [JsonPropertyName("limit_multi_searches")]
-    public int? LimitMultiSearches { get; init; }
-
-    /// <summary>
-    /// Page number of the merged (unioned) result set to return.
-    /// Pagination is applied after results from all searches are combined.
-    /// </summary>
-    [JsonPropertyName("page")]
-    public int? Page { get; init; }
-
-    /// <summary>
-    /// Number of results to return per page from the unified result set.
-    /// Pagination is applied after merging results from all searches.
-    /// </summary>
-    [JsonPropertyName("per_page")]
-    public int? PerPage { get; init; }
-
-    // ---------------------------------------------------------------------------------------
-    // Caching parameters - https://typesense.org/docs/latest/api/search.html#caching-parameters
-    // ---------------------------------------------------------------------------------------
-    // cache_ttl can only be set as part of a scoped API key, and not as a search parameter.
-
-    /// <summary>
-    /// Enable server side caching of search query results. By default, caching is disabled.
-    /// Default: false
-    /// </summary>
-    [JsonPropertyName("use_cache")]
-    public bool? UseCache { get; set; }
-
-    public UnionSearchParameters(
-        int? limitMultiSearches = null,
-        int? page = null,
-        int? perPage = null,
-        bool? useCache = null)
-    {
-        LimitMultiSearches = limitMultiSearches;
-        Page = page;
-        PerPage = perPage;
-        UseCache = useCache;
-    }
-}
-
-/// <summary>
 /// Common parameters used for performing a single call with multiple <see cref="MultiSearchParameters"/>
 /// where multiple searches are executed in a single call.
 /// See: https://typesense.org/docs/30.1/api/federated-multi-search.html#multi-search-parameters
@@ -700,3 +645,38 @@ public record CommonMultiSearchParameters
     }
 }
 
+
+
+/// <summary>
+/// Parameters used for performing a Union search,
+/// where results from multiple searches are combined into a single
+/// unified result set and then paginated.
+/// See: https://typesense.org/docs/30.1/api/federated-multi-search.html#union-search
+/// </summary>
+public record UnionSearchParameters : CommonMultiSearchParameters
+{
+    /// <summary>
+    /// Page number of the merged (unioned) result set to return.
+    /// Pagination is applied after results from all searches are combined.
+    /// </summary>
+    [JsonPropertyName("page")]
+    public int? Page { get; init; }
+
+    /// <summary>
+    /// Number of results to return per page from the unified result set.
+    /// Pagination is applied after merging results from all searches.
+    /// </summary>
+    [JsonPropertyName("per_page")]
+    public int? PerPage { get; init; }
+
+    public UnionSearchParameters(
+        int? limitMultiSearches = null,
+        int? page = null,
+        int? perPage = null,
+        bool? useCache = null)
+        : base (limitMultiSearches, useCache)
+    {
+        Page = page;
+        PerPage = perPage;
+    }
+}

--- a/src/Typesense/SearchParameters.cs
+++ b/src/Typesense/SearchParameters.cs
@@ -516,6 +516,7 @@ public record SearchParameters
     // ---------------------------------------------------------------------------------------
     // Caching parameters - https://typesense.org/docs/latest/api/search.html#caching-parameters
     // ---------------------------------------------------------------------------------------
+    // cache_ttl can only be set as part of a scoped API key, and not as a search parameter.
 
     /// <summary>
     /// Enable server side caching of search query results. By default, caching is disabled.
@@ -523,14 +524,6 @@ public record SearchParameters
     /// </summary>
     [JsonPropertyName("use_cache")]
     public bool? UseCache { get; set; }
-
-    /// <summary>
-    /// The duration (in seconds) that determines how long the search query is cached.
-    /// This value can only be set as part of a scoped API key.
-    /// Default: 60
-    /// </summary>
-    [JsonPropertyName("cache_ttl")]
-    public int? CacheTtl { get; set; }
 
     /// <summary>
     /// How long to wait until an API call to a remote embedding service is considered a timeout.
@@ -646,13 +639,64 @@ public record UnionSearchParameters
     [JsonPropertyName("per_page")]
     public int? PerPage { get; init; }
 
+    // ---------------------------------------------------------------------------------------
+    // Caching parameters - https://typesense.org/docs/latest/api/search.html#caching-parameters
+    // ---------------------------------------------------------------------------------------
+    // cache_ttl can only be set as part of a scoped API key, and not as a search parameter.
+
+    /// <summary>
+    /// Enable server side caching of search query results. By default, caching is disabled.
+    /// Default: false
+    /// </summary>
+    [JsonPropertyName("use_cache")]
+    public bool? UseCache { get; set; }
+
     public UnionSearchParameters(
         int? limitMultiSearches = null,
         int? page = null,
-        int? perPage = null)
+        int? perPage = null,
+        bool? useCache = null)
     {
         LimitMultiSearches = limitMultiSearches;
         Page = page;
         PerPage = perPage;
+        UseCache = useCache;
     }
 }
+
+/// <summary>
+/// Common parameters used for performing a single call with multiple <see cref="MultiSearchParameters"/>
+/// where multiple searches are executed in a single call.
+/// See: https://typesense.org/docs/30.1/api/federated-multi-search.html#multi-search-parameters
+/// </summary>
+public record CommonMultiSearchParameters
+{
+    /// <summary>
+    /// Limits the number of individual searches from a multi-search request
+    /// that are considered when generating the unified result set.
+    /// This can be used to control performance when many searches are included.
+    /// </summary>
+    [JsonPropertyName("limit_multi_searches")]
+    public int? LimitMultiSearches { get; init; }
+
+    // ---------------------------------------------------------------------------------------
+    // Caching parameters - https://typesense.org/docs/latest/api/search.html#caching-parameters
+    // ---------------------------------------------------------------------------------------
+    // cache_ttl can only be set as part of a scoped API key, and not as a search parameter.
+
+    /// <summary>
+    /// Enable server side caching of search query results. By default, caching is disabled.
+    /// Default: false
+    /// </summary>
+    [JsonPropertyName("use_cache")]
+    public bool? UseCache { get; set; }
+
+    public CommonMultiSearchParameters(
+        int? limitMultiSearches = null,
+        bool? useCache = null)
+    {
+        LimitMultiSearches = limitMultiSearches;
+        UseCache = useCache;
+    }
+}
+

--- a/src/Typesense/Typesense.csproj
+++ b/src/Typesense/Typesense.csproj
@@ -6,6 +6,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisMode>All</AnalysisMode>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
 
     <PackageId>Typesense</PackageId>
     <Description>.NET HTTP client for Typesense.</Description>

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -171,60 +171,68 @@ public class TypesenseClient : ITypesenseClient
             ?? throw new InvalidOperationException($"Could not deserialize {typeof(T)}, Received following from Typesense: '{response}'.");
     }
 
-    public async Task<List<MultiSearchResult<T>>> MultiSearch<T>(ICollection<MultiSearchParameters> s1, int? limitMultiSearches = null, CancellationToken ctk = default)
+    private async Task<JsonElement> MultiSearch(
+        ICollection<MultiSearchParameters> searches,
+        CommonMultiSearchParameters? parms = null,
+        CancellationToken ctk = default)
     {
-        var searches = new { Searches = s1 };
-        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
+        var wrapper = new { Searches = searches };
+        using var json = JsonContent.Create(wrapper, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
 
-        var path = limitMultiSearches is null
-            ? "/multi_search"
-            : $"/multi_search?limit_multi_searches={limitMultiSearches}";
+        var queryString = parms != null ? CreateUrlParameters(parms) : null;
 
+        var path = queryString?.Length > 0
+            ? $"/multi_search?{queryString}"
+            : "/multi_search";
+        
         var response = await Post<JsonElement>(path, json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 
         return response.TryGetProperty("results", out var results)
-            ? results.EnumerateArray().Select(HandleDeserializeMultiSearch<T>).ToList()
+            ? results
             : throw new InvalidOperationException("Could not get 'results' property from multi-search response.");
     }
 
-    public async Task<MultiSearchResult<T>> MultiSearch<T>(MultiSearchParameters s1, CancellationToken ctk = default)
+    public async Task<List<MultiSearchResult<T>>> MultiSearch<T>(
+        ICollection<MultiSearchParameters> s1, 
+        CommonMultiSearchParameters? parms = null, 
+        CancellationToken ctk = default)
     {
-        var searches = new { Searches = new MultiSearchParameters[] { s1 } };
-        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var results = await MultiSearch(s1, parms, ctk).ConfigureAwait(false);
 
-        return response.TryGetProperty("results", out var results)
-            ? HandleDeserializeMultiSearch<T>(results[0])
-            : throw new InvalidOperationException("Could not get results from multi-search result.");
+        return results.EnumerateArray().Select(HandleDeserializeMultiSearch<T>).ToList();
     }
 
-    public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>)> MultiSearch<T1, T2>(MultiSearchParameters s1, MultiSearchParameters s2, CancellationToken ctk = default)
+    public async Task<MultiSearchResult<T>> MultiSearch<T>(MultiSearchParameters s1, CommonMultiSearchParameters? parms = null, CancellationToken ctk = default)
     {
-        var searches = new { Searches = new MultiSearchParameters[] { s1, s2 } };
-        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var results = await MultiSearch([s1], parms, ctk).ConfigureAwait(false);
 
-        return response.TryGetProperty("results", out var results)
-            ? (HandleDeserializeMultiSearch<T1>(results[0]),
-               HandleDeserializeMultiSearch<T2>(results[1]))
-            : throw new InvalidOperationException("Could not get results from multi-search result.");
+        return HandleDeserializeMultiSearch<T>(results[0]);
+    }
+
+    public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>)> MultiSearch<T1, T2>(
+        MultiSearchParameters s1, 
+        MultiSearchParameters s2,
+        CommonMultiSearchParameters? parms = null, 
+        CancellationToken ctk = default)
+    {
+        var results = await MultiSearch([s1, s2], parms, ctk).ConfigureAwait(false);
+
+        return (HandleDeserializeMultiSearch<T1>(results[0]),
+               HandleDeserializeMultiSearch<T2>(results[1]));
     }
 
     public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>)> MultiSearch<T1, T2, T3>(
         MultiSearchParameters s1,
         MultiSearchParameters s2,
         MultiSearchParameters s3,
+        CommonMultiSearchParameters? parms = null,
         CancellationToken ctk = default)
     {
-        var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3 } };
-        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var results = await MultiSearch([s1, s2, s3], parms, ctk).ConfigureAwait(false);
 
-        return response.TryGetProperty("results", out var results)
-            ? (HandleDeserializeMultiSearch<T1>(results[0]),
+        return (HandleDeserializeMultiSearch<T1>(results[0]),
                HandleDeserializeMultiSearch<T2>(results[1]),
-               HandleDeserializeMultiSearch<T3>(results[2]))
-            : throw new InvalidOperationException("Could not get results from multi-search result.");
+               HandleDeserializeMultiSearch<T3>(results[2]));
     }
 
     public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>)> MultiSearch<T1, T2, T3, T4>(
@@ -232,18 +240,15 @@ public class TypesenseClient : ITypesenseClient
         MultiSearchParameters s2,
         MultiSearchParameters s3,
         MultiSearchParameters s4,
+        CommonMultiSearchParameters? parms = null,
         CancellationToken ctk = default)
     {
-        var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4 } };
-        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var results = await MultiSearch([s1, s2, s3, s4], parms, ctk).ConfigureAwait(false);
 
-        return (response.TryGetProperty("results", out var results))
-            ? (HandleDeserializeMultiSearch<T1>(results[0]),
+        return (HandleDeserializeMultiSearch<T1>(results[0]),
                HandleDeserializeMultiSearch<T2>(results[1]),
                HandleDeserializeMultiSearch<T3>(results[2]),
-               HandleDeserializeMultiSearch<T4>(results[3]))
-            : throw new InvalidOperationException("Could not get results from multi-search result.");
+               HandleDeserializeMultiSearch<T4>(results[3]));
     }
 
     public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>)> MultiSearch<T1, T2, T3, T4, T5>(
@@ -252,19 +257,16 @@ public class TypesenseClient : ITypesenseClient
         MultiSearchParameters s3,
         MultiSearchParameters s4,
         MultiSearchParameters s5,
+        CommonMultiSearchParameters? parms = null,
         CancellationToken ctk = default)
     {
-        var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5 } };
-        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var results = await MultiSearch([s1, s2, s3, s4, s5], parms, ctk).ConfigureAwait(false);
 
-        return response.TryGetProperty("results", out var results)
-            ? (HandleDeserializeMultiSearch<T1>(results[0]),
+        return (HandleDeserializeMultiSearch<T1>(results[0]),
                HandleDeserializeMultiSearch<T2>(results[1]),
                HandleDeserializeMultiSearch<T3>(results[2]),
                HandleDeserializeMultiSearch<T4>(results[3]),
-               HandleDeserializeMultiSearch<T5>(results[4]))
-            : throw new InvalidOperationException("Could not get results from multi-search result.");
+               HandleDeserializeMultiSearch<T5>(results[4]));
     }
 
     public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>)> MultiSearch<T1, T2, T3, T4, T5, T6>(
@@ -274,20 +276,17 @@ public class TypesenseClient : ITypesenseClient
         MultiSearchParameters s4,
         MultiSearchParameters s5,
         MultiSearchParameters s6,
+        CommonMultiSearchParameters? parms = null,
         CancellationToken ctk = default)
     {
-        var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5, s6 } };
-        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var results = await MultiSearch([s1, s2, s3, s4, s5, s6], parms, ctk).ConfigureAwait(false);
 
-        return response.TryGetProperty("results", out var results)
-            ? (HandleDeserializeMultiSearch<T1>(results[0]),
+        return (HandleDeserializeMultiSearch<T1>(results[0]),
                HandleDeserializeMultiSearch<T2>(results[1]),
                HandleDeserializeMultiSearch<T3>(results[2]),
                HandleDeserializeMultiSearch<T4>(results[3]),
                HandleDeserializeMultiSearch<T5>(results[4]),
-               HandleDeserializeMultiSearch<T6>(results[5]))
-            : throw new InvalidOperationException("Could not get results from multi-search result.");
+               HandleDeserializeMultiSearch<T6>(results[5]));
     }
 
     public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>, MultiSearchResult<T7>)> MultiSearch<T1, T2, T3, T4, T5, T6, T7>(
@@ -298,21 +297,18 @@ public class TypesenseClient : ITypesenseClient
         MultiSearchParameters s5,
         MultiSearchParameters s6,
         MultiSearchParameters s7,
+        CommonMultiSearchParameters? parms = null,
         CancellationToken ctk = default)
     {
-        var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5, s6, s7 } };
-        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var results = await MultiSearch([s1, s2, s3, s4, s5, s6, s7], parms, ctk).ConfigureAwait(false);
 
-        return response.TryGetProperty("results", out var results)
-            ? (HandleDeserializeMultiSearch<T1>(results[0]),
+        return (HandleDeserializeMultiSearch<T1>(results[0]),
                HandleDeserializeMultiSearch<T2>(results[1]),
                HandleDeserializeMultiSearch<T3>(results[2]),
                HandleDeserializeMultiSearch<T4>(results[3]),
                HandleDeserializeMultiSearch<T5>(results[4]),
                HandleDeserializeMultiSearch<T6>(results[5]),
-               HandleDeserializeMultiSearch<T7>(results[6]))
-            : throw new InvalidOperationException("Could not get results from multi-search result.");
+               HandleDeserializeMultiSearch<T7>(results[6]));
     }
 
     public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>, MultiSearchResult<T7>, MultiSearchResult<T8>)> MultiSearch<T1, T2, T3, T4, T5, T6, T7, T8>(
@@ -324,22 +320,19 @@ public class TypesenseClient : ITypesenseClient
         MultiSearchParameters s6,
         MultiSearchParameters s7,
         MultiSearchParameters s8,
+        CommonMultiSearchParameters? parms = null,
         CancellationToken ctk = default)
     {
-        var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5, s6, s7, s8 } };
-        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var results = await MultiSearch([s1, s2, s3, s4, s5, s6, s7, s8], parms, ctk).ConfigureAwait(false);
 
-        return response.TryGetProperty("results", out var results)
-            ? (HandleDeserializeMultiSearch<T1>(results[0]),
+        return (HandleDeserializeMultiSearch<T1>(results[0]),
                HandleDeserializeMultiSearch<T2>(results[1]),
                HandleDeserializeMultiSearch<T3>(results[2]),
                HandleDeserializeMultiSearch<T4>(results[3]),
                HandleDeserializeMultiSearch<T5>(results[4]),
                HandleDeserializeMultiSearch<T6>(results[5]),
                HandleDeserializeMultiSearch<T7>(results[6]),
-               HandleDeserializeMultiSearch<T8>(results[7]))
-            : throw new InvalidOperationException("Could not get results from multi-search result.");
+               HandleDeserializeMultiSearch<T8>(results[7]));
     }
 
     public async Task<(MultiSearchResult<T1>, MultiSearchResult<T2>, MultiSearchResult<T3>, MultiSearchResult<T4>, MultiSearchResult<T5>, MultiSearchResult<T6>, MultiSearchResult<T7>, MultiSearchResult<T8>, MultiSearchResult<T9>)> MultiSearch<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
@@ -352,14 +345,12 @@ public class TypesenseClient : ITypesenseClient
         MultiSearchParameters s7,
         MultiSearchParameters s8,
         MultiSearchParameters s9,
+        CommonMultiSearchParameters? parms = null,
         CancellationToken ctk = default)
     {
-        var searches = new { Searches = new MultiSearchParameters[] { s1, s2, s3, s4, s5, s6, s7, s8, s9 } };
-        using var json = JsonContent.Create(searches, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
-        var response = await Post<JsonElement>("/multi_search", json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
+        var results = await MultiSearch([s1, s2, s3, s4, s5, s6, s7, s8, s9], parms, ctk).ConfigureAwait(false);
 
-        return response.TryGetProperty("results", out var results)
-            ? (HandleDeserializeMultiSearch<T1>(results[0]),
+        return (HandleDeserializeMultiSearch<T1>(results[0]),
                HandleDeserializeMultiSearch<T2>(results[1]),
                HandleDeserializeMultiSearch<T3>(results[2]),
                HandleDeserializeMultiSearch<T4>(results[3]),
@@ -367,8 +358,7 @@ public class TypesenseClient : ITypesenseClient
                HandleDeserializeMultiSearch<T6>(results[5]),
                HandleDeserializeMultiSearch<T7>(results[6]),
                HandleDeserializeMultiSearch<T8>(results[7]),
-               HandleDeserializeMultiSearch<T9>(results[8]))
-            : throw new InvalidOperationException("Could not get results from multi-search result.");
+               HandleDeserializeMultiSearch<T9>(results[8]));
     }
 
     public Task<T> RetrieveDocument<T>(string collection, string id, CancellationToken ctk = default) where T : class

--- a/src/Typesense/TypesenseClient.cs
+++ b/src/Typesense/TypesenseClient.cs
@@ -148,22 +148,17 @@ public class TypesenseClient : ITypesenseClient
     {
         return SearchInternal<SearchGroupedResult<T>>(collection, groupedSearchParameters, ctk);
     }
-    public async Task<UnionSearchResult<T>> UnionSearch<T>(ICollection<MultiSearchParameters> s1, int? limitMultiSearches = null, int? page = null, int? perPage = null, CancellationToken ctk = default)
+
+    public async Task<UnionSearchResult<T>> UnionSearch<T>(ICollection<MultiSearchParameters> s1, UnionSearchParameters? parms = null, CancellationToken ctk = default)
     {
         var body = new { union = true, Searches = s1 };
         using var json = JsonContent.Create(body, JsonMediaTypeHeaderValue, _jsonOptionsCamelCaseIgnoreWritingNull);
 
-        var queryParams = new UnionSearchParameters
-        {
-            LimitMultiSearches = limitMultiSearches,
-            Page = page,
-            PerPage = perPage
-        };
-        var queryString = CreateUrlParameters(queryParams);
+        var queryString = parms != null ? CreateUrlParameters(parms) : null;
 
-        var path = queryString.Length == 0 
-            ? "/multi_search" 
-            : $"/multi_search?{queryString}";
+        var path = queryString?.Length > 0
+            ? $"/multi_search?{queryString}"
+            : "/multi_search";
 
         var response = await Post<JsonElement>(path, json, jsonSerializerOptions: null, ctk).ConfigureAwait(false);
 

--- a/test/Typesense.Tests/TypesenseClientTests.cs
+++ b/test/Typesense.Tests/TypesenseClientTests.cs
@@ -1591,6 +1591,29 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
     }
 
     [Fact, TestPriority(11)]
+    public async Task Search_use_cache()
+    {
+        var query = new SearchParameters("Stark", "company_name")
+        {
+            UseCache = true,
+
+            // Sort randomly so we can validate whether results were cached.
+            SortBy = "_rand(42):asc"
+        };
+
+        var response1 = await _client.Search<Company>("companies", query);
+        var firstCompany = response1.Hits.First().Document;
+
+        // Search again with the same query, if caching works, we should get the same random sort order and thus the same first company.
+        var response2 = await _client.Search<Company>("companies", query);
+
+        using (var scope = new AssertionScope())
+        {
+            response2.Hits.First().Document.Should().BeEquivalentTo(firstCompany);
+        }
+    }
+
+    [Fact, TestPriority(11)]
     public async Task Multi_search_query_single_type_multiple_multi_search_parameters()
     {
         var expected = new Company
@@ -1695,6 +1718,26 @@ public class TypesenseClientTests : IClassFixture<TypesenseFixture>
         {
             response.Found.Should().Be(1);
             response.Hits.First().Document.Should().BeEquivalentTo(expected);
+        }
+    }
+
+    [Fact, TestPriority(11)]
+    public async Task Multi_search_query_use_cache()
+    {
+        var query = new MultiSearchParameters("companies", "*", "company_name")
+        {
+            // Sort randomly so we can validate whether results were cached.
+            SortBy = "_rand(42):asc"
+        };
+        var response1 = await _client.MultiSearch<Company>(query, new CommonMultiSearchParameters(useCache: true));
+        var firstCompany = response1.Hits.First().Document;
+
+        // Search again with the same query, if caching works, we should get the same random sort order and thus the same first company.
+        var response2 = await _client.MultiSearch<Company>(query, new CommonMultiSearchParameters(useCache: true));
+
+        using (var scope = new AssertionScope())
+        {
+            response2.Hits.First().Document.Should().BeEquivalentTo(firstCompany);
         }
     }
 

--- a/test/Typesense.Tests/TypesenseFixture.cs
+++ b/test/Typesense.Tests/TypesenseFixture.cs
@@ -50,10 +50,10 @@ public class TypesenseFixture : IAsyncLifetime
         return new ServiceCollection()
             .AddTypesenseClient(config =>
             {
-                config.ApiKey = "typesense-api-key";
+                config.ApiKey = "key";
                 config.Nodes = new List<Node>
                 {
-                    new Node("localhost", "32771", "http")
+                    new Node("localhost", "8108", "http")
                 };
             }, enableHttpCompression: true).BuildServiceProvider().GetService<ITypesenseClient>();
     }

--- a/test/Typesense.Tests/TypesenseFixture.cs
+++ b/test/Typesense.Tests/TypesenseFixture.cs
@@ -50,10 +50,10 @@ public class TypesenseFixture : IAsyncLifetime
         return new ServiceCollection()
             .AddTypesenseClient(config =>
             {
-                config.ApiKey = "key";
+                config.ApiKey = "typesense-api-key";
                 config.Nodes = new List<Node>
                 {
-                    new Node("localhost", "8108", "http")
+                    new Node("localhost", "32771", "http")
                 };
             }, enableHttpCompression: true).BuildServiceProvider().GetService<ITypesenseClient>();
     }


### PR DESCRIPTION
'use_cache' parameter needs to be set in the query string, instead of the body, see https://typesense.org/docs/30.1/api/search.html#caching-parameters