### PR TITLE
fix: Use InvariantCulture in GroupKeyConverter to support InvariantGlobalization mode

### DIFF
--- a/src/Typesense/Converter/GroupKeyConverter.cs
+++ b/src/Typesense/Converter/GroupKeyConverter.cs
@@ -24,7 +24,7 @@ public class GroupKeyConverter : JsonConverter<IReadOnlyList<string>>
             JsonValueKind.String => element.GetString(),
             JsonValueKind.False => "false",
             JsonValueKind.True => "true",
-            JsonValueKind.Number => element.GetDecimal().ToString(CultureInfo.CreateSpecificCulture("en-US")),
+            JsonValueKind.Number => element.GetDecimal().ToString(CultureInfo.InvariantCulture),
             JsonValueKind.Array => string.Join(", ", element.EnumerateArray().Select(StringifyJsonElement)),
             _ => null
         };


### PR DESCRIPTION
This PR makes a small change to the `StringifyJsonElement` method in `GroupKeyConverter.cs` to improve the consistency of number formatting. The method now uses `CultureInfo.InvariantCulture` instead of a specific "en-US" culture when converting numbers to strings. This change also enables the support of `InvariantGlobalization` mode. Otherwise, a locale exception is thrown.