### PR TITLE
Feat: Add collection and search_index properties to Hit record (returned in union_search response)

### DIFF
--- a/src/Typesense/SearchResult.cs
+++ b/src/Typesense/SearchResult.cs
@@ -72,6 +72,12 @@ public record Hit<T>
     [JsonPropertyName("hybrid_search_info")]
     public HybridSearchInfo? HybridSearchInfo { get; init; }
 
+    [JsonPropertyName("collection")]
+    public string? Collection { get; init; }
+
+    [JsonPropertyName("search_index")]
+    public int? SearchIndex { get; init; }
+
     [JsonConstructor]
     public Hit(IReadOnlyList<Highlight> highlights, T document, long? textMatch, double? vectorDistance, IReadOnlyDictionary<string, double>? geoDistanceMeters)
     {


### PR DESCRIPTION
This PR adds two new properties to the `Hit<T>` record in `SearchResult.cs` to provide additional metadata about search results. These properties allow consumers of the API to identify the collection and the search index associated with each hit.

Enhancements to search result metadata:

* Added a nullable `Collection` property to indicate the collection from which the search hit originated.
* Added a nullable `SearchIndex` property to specify the search index of the hit.

These properties are populated as part of a union-search response.